### PR TITLE
[IDEA] gtk3の実験的サポート R2

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@
 > make
 > ```
 
+### Arch Linux
+> gtk3版のビルドファイルはAURで公開されている。(Thanks to @naniwaKun.)  
+> https://aur.archlinux.org/packages/jd-gtk3/
+>
+> AUR Helper [yay](https://github.com/Jguer/yay) でインストール
+> ```sh
+> yay -S jd-gtk3
+> ```
+
 # 参考
 　詳しいインストールの方法は [本家のwiki](https://ja.osdn.net/projects/jd4linux/wiki/OS%2f%E3%83%87%E3%82%A3%E3%82%B9%E3%83%88%E3%83%AA%E3%83%93%E3%83%A5%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E5%88%A5%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E6%96%B9%E6%B3%95) を参照。
 

--- a/src/article/articleadmin.cpp
+++ b/src/article/articleadmin.cpp
@@ -62,6 +62,10 @@ ArticleAdmin::ArticleAdmin( const std::string& url )
 
     get_notebook()->set_dragable( true );
     get_notebook()->set_fixtab( false );
+#if GTKMM_CHECK_VERSION(3,0,0)
+    // XXX: ArticleAdminで起こる描画崩れを直すためのタイマーを有効にする
+    get_notebook()->set_timeout_drawn( true );
+#endif
     if( ! SESSION::get_show_article_tab() ) get_notebook()->set_show_tabs( false );
 
     setup_menu();

--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -40,6 +40,10 @@
 #include <sstream>
 #include <cstring>
 
+#if GTKMM_CHECK_VERSION(3,0,0) && !defined( USE_PANGOLAYOUT )
+#include <pangomm/glyphstring.h>
+#endif
+
 using namespace ARTICLE;
 
 enum
@@ -96,18 +100,32 @@ DrawAreaBase::DrawAreaBase( const std::string& url )
     , m_layout_tree( 0 )
     , m_seen_current( 0 )
     , m_window( 0 )
+#if GTKMM_CHECK_VERSION(2,22,0)
+    , m_cr( nullptr, cairo_destroy )
+    , m_backscreen( nullptr, cairo_surface_destroy )
+#else
     , m_gc( 0 )
     , m_backscreen( NULL )
+#endif
     , m_pango_layout( 0 )
     , m_draw_frame( false )
+#if GTKMM_CHECK_VERSION(2,22,0)
+    , m_back_frame_top( nullptr, cairo_surface_destroy )
+    , m_back_frame_bottom( nullptr, cairo_surface_destroy )
+#else
     , m_back_frame( NULL )
+#endif
     , m_ready_back_frame( false )
     , m_aafont_initialized( false )
     , m_strict_of_char( false )
     , m_configure_reserve( false )
     , m_configure_width( 0 )
     , m_configure_height( 0 )
+#if GTKMM_CHECK_VERSION(2,22,0)
+    , m_back_marker( nullptr, cairo_surface_destroy )
+#else
     , m_back_marker( NULL )
+#endif
     , m_ready_back_marker( false )
     , m_wait_scroll( 0 )
     , m_cursor_type( Gdk::ARROW )
@@ -459,7 +477,11 @@ void DrawAreaBase::focus_view()
 void DrawAreaBase::focus_out()
 {
     // realize していない
+#if GTKMM_CHECK_VERSION(2,22,0)
+    if( !m_window ) return;
+#else
     if( !m_gc ) return;
+#endif
 
 #ifdef _DEBUG
     std::cout << "DrawAreaBase::focus_out\n";
@@ -1123,14 +1145,26 @@ const bool DrawAreaBase::exec_layout_impl( const bool is_popup, const int offset
     std::cout << "create backscreen : width = " << m_view.get_width() << " height = " << m_view.get_height() << std::endl;
 #endif
 
+#if GTKMM_CHECK_VERSION(2,22,0)
+    m_backscreen.reset( gdk_window_create_similar_surface(
+        m_window->gobj(), CAIRO_CONTENT_COLOR, m_view.get_width(), m_view.get_height() ) );
+#else
     m_backscreen.reset();
     m_backscreen = Gdk::Pixmap::create( m_window, m_view.get_width(), m_view.get_height() );
+#endif
 
     m_rect_backscreen.y = 0;
     m_rect_backscreen.height = 0;
 
+#if GTKMM_CHECK_VERSION(2,22,0)
+    m_back_frame_top.reset( gdk_window_create_similar_surface(
+        m_window->gobj(), CAIRO_CONTENT_COLOR, m_view.get_width(), WIDTH_FRAME ) );
+    m_back_frame_bottom.reset( gdk_window_create_similar_surface(
+        m_window->gobj(), CAIRO_CONTENT_COLOR, m_view.get_width(), WIDTH_FRAME ) );
+#else
     m_back_frame.reset();
     m_back_frame = Gdk::Pixmap::create( m_window, m_view.get_width(), WIDTH_FRAME * 2 );
+#endif
 
     m_ready_back_frame = false;
 
@@ -1679,7 +1713,9 @@ const int DrawAreaBase::get_width_of_one_char( const char* utfstr, int& byte, ch
 const bool DrawAreaBase::draw_screen( const int y, const int height )
 {
     if( ! m_enable_draw ) return false;
+#if !GTKMM_CHECK_VERSION(2,22,0)
     if( ! m_gc ) return false;
+#endif
     if( ! m_backscreen ) return false;
     if( ! m_layout_tree ) return false;
     if( ! m_layout_tree->top_header() ) return false;
@@ -1805,23 +1841,52 @@ void DrawAreaBase::exec_draw_screen( const int y_redraw, const int height_redraw
     m_rect_backscreen.width = width_view;
     m_rect_backscreen.height = height_screen;
 
+#if !GTKMM_CHECK_VERSION(2,22,0)
     Gdk::Rectangle rect_clip( 0, y_screen, width_view, height_screen );
     m_gc->set_clip_rectangle( rect_clip );
+#endif
 
     // バックスクリーンをスクロール処理する
     if( ! m_scroll_window ){
 
+#if GTKMM_CHECK_VERSION(2,22,0)
+        cairo_t* scroll_cr = cairo_create( m_backscreen.get() );
+        cairo_rectangle( scroll_cr, 0.0, 0.0, width_view, height_view );
+        cairo_clip( scroll_cr );
+#else
         rect_clip.set_y( 0 );
         rect_clip.set_height( height_view );
         m_gc->set_clip_rectangle( rect_clip );
+#endif
 
         // 上にスクロールした
-        if( dy > 0 && dy < height_view )
+        if( dy > 0 && dy < height_view ) {
+#if GTKMM_CHECK_VERSION(2,22,0)
+            cairo_push_group( scroll_cr );
+            cairo_set_source_surface( scroll_cr, m_backscreen.get(), 0.0, dy );
+            cairo_paint( scroll_cr );
+            cairo_pop_group_to_source( scroll_cr );
+            cairo_paint( scroll_cr );
+#else
             m_backscreen->draw_drawable( m_gc, m_backscreen, 0, dy, 0, 0, width_view , height_view - dy );
+#endif
+        }
 
         // 下にスクロールした
-        else if( dy < 0 && -dy < height_view )
+        else if( dy < 0 && -dy < height_view ) {
+#if GTKMM_CHECK_VERSION(2,22,0)
+            cairo_push_group( scroll_cr );
+            cairo_set_source_surface( scroll_cr, m_backscreen.get(), 0.0, dy );
+            cairo_paint( scroll_cr );
+            cairo_pop_group_to_source( scroll_cr );
+            cairo_paint( scroll_cr );
+#else
             m_backscreen->draw_drawable( m_gc, m_backscreen, 0, 0, 0, -dy, width_view , height_view + dy );
+#endif
+        }
+#if GTKMM_CHECK_VERSION(2,22,0)
+        cairo_destroy( scroll_cr );
+#endif
 
         m_rect_backscreen.y = 0;
         m_rect_backscreen.height = height_view;
@@ -1888,8 +1953,18 @@ void DrawAreaBase::exec_draw_screen( const int y_redraw, const int height_redraw
     }
 
     // バックスクリーンの背景クリア
+#if GTKMM_CHECK_VERSION(2,22,0)
+    {
+        cairo_t* cr = cairo_create( m_backscreen.get() );
+        gdk_cairo_set_source_color( cr, m_color[ get_colorid_back() ].gobj() );
+        cairo_rectangle( cr, 0.0, y_screen, width_view, height_screen );
+        cairo_fill( cr );
+        cairo_destroy( cr );
+    }
+#else
     m_gc->set_foreground( m_color[ get_colorid_back() ] );
     m_backscreen->draw_rectangle( m_gc, true, 0, y_screen, width_view, height_screen );
+#endif
 
     // 描画ループ
     CLIPINFO ci = { width_view, pos_y, upper, lower }; // 描画領域
@@ -1985,6 +2060,14 @@ void DrawAreaBase::exec_draw_screen( const int y_redraw, const int height_redraw
 
             m_ready_back_marker = false;
 
+#if GTKMM_CHECK_VERSION(2,22,0)
+            cairo_save( m_cr.get() );
+            cairo_rectangle( m_cr.get(), m_clip_marker.x, m_clip_marker.y, m_clip_marker.width, m_clip_marker.height );
+            cairo_clip( m_cr.get() );
+            cairo_set_source_surface( m_cr.get(), m_back_marker.get(), m_clip_marker.x, m_clip_marker.y );
+            cairo_paint( m_cr.get() );
+            cairo_restore( m_cr.get() );
+#else
             // [gtkmm <= 2.8] Gdk::GC::set_clip_rectangle( Gdk::Rectangle& rectangle )
             // Gdk::GC::set_clip_rectangle( const Gdk::Rectangle& rectangle )
             Gdk::Rectangle rect_window( m_clip_marker.x, m_clip_marker.y, m_clip_marker.width, m_clip_marker.height );
@@ -1993,6 +2076,7 @@ void DrawAreaBase::exec_draw_screen( const int y_redraw, const int height_redraw
                                      m_clip_marker.x, m_clip_marker.y, m_clip_marker.width, m_clip_marker.height );
 
             m_gc->set_clip_rectangle( rect_clip );
+#endif
         }
 
         // 前回描画したフレームを消す
@@ -2000,6 +2084,16 @@ void DrawAreaBase::exec_draw_screen( const int y_redraw, const int height_redraw
 
             m_ready_back_frame = false;
 
+#if GTKMM_CHECK_VERSION(2,22,0)
+            cairo_save( m_cr.get() );
+            cairo_rectangle( m_cr.get(), 0.0, 0.0, width_view, height_view );
+            cairo_clip( m_cr.get() );
+            cairo_set_source_surface( m_cr.get(), m_back_frame_top.get(), 0.0, 0.0 );
+            cairo_paint( m_cr.get() );
+            cairo_set_source_surface( m_cr.get(), m_back_frame_bottom.get(), 0.0, height_view - WIDTH_FRAME );
+            cairo_paint( m_cr.get() );
+            cairo_restore( m_cr.get() );
+#else
             // [gtkmm <= 2.8] Gdk::GC::set_clip_rectangle( Gdk::Rectangle& rectangle )
             // Gdk::GC::set_clip_rectangle( const Gdk::Rectangle& rectangle )
             Gdk::Rectangle rect_frame( 0, 0, width_view, height_view );
@@ -2008,6 +2102,7 @@ void DrawAreaBase::exec_draw_screen( const int y_redraw, const int height_redraw
             m_window->draw_drawable( m_gc, m_back_frame, 0, WIDTH_FRAME, 0, height_view - WIDTH_FRAME, width_view, WIDTH_FRAME );
 
             m_gc->set_clip_rectangle( rect_clip );
+#endif
         }
 
 
@@ -2019,7 +2114,16 @@ void DrawAreaBase::exec_draw_screen( const int y_redraw, const int height_redraw
         }
 
         // 更新した所だけバックスクリーンをウィンドウにコピー
+#if GTKMM_CHECK_VERSION(2,22,0)
+        cairo_save( m_cr.get() );
+        cairo_rectangle( m_cr.get(), 0.0, y_screen, width_view, height_screen );
+        cairo_clip( m_cr.get() );
+        cairo_set_source_surface( m_cr.get(), m_backscreen.get(), 0.0, 0.0 );
+        cairo_paint( m_cr.get() );
+        cairo_restore( m_cr.get() );
+#else
         m_window->draw_drawable( m_gc, m_backscreen, 0, y_screen, 0, y_screen, width_view, height_screen );
+#endif
     }
 
     // バックスクリーンを全てウィンドウにコピー
@@ -2028,7 +2132,16 @@ void DrawAreaBase::exec_draw_screen( const int y_redraw, const int height_redraw
 #ifdef _DEBUG
         std::cout << "copy all\n";
 #endif
+#if GTKMM_CHECK_VERSION(2,22,0)
+        cairo_save( m_cr.get() );
+        cairo_rectangle( m_cr.get(), 0.0, 0.0, width_view, height_view );
+        cairo_clip( m_cr.get() );
+        cairo_set_source_surface( m_cr.get(), m_backscreen.get(), 0.0, 0.0 );
+        cairo_paint( m_cr.get() );
+        cairo_restore( m_cr.get() );
+#else
         m_window->draw_drawable( m_gc, m_backscreen, 0, 0, 0, 0, width_view, height_view );
+#endif
     }
 
     // オートスクロールマーカと枠の描画
@@ -2141,9 +2254,20 @@ bool DrawAreaBase::draw_one_node( LAYOUT* layout, const CLIPINFO& ci )
                     const int s_bottom = MIN( height_bkmk, ci.lower - y );
                     const int height = s_bottom - s_top;
 
-                    if( height > 0 ) m_backscreen->draw_pixbuf( m_gc, m_pixbuf_bkmk,
-                                                                0, s_top, 1, y - ci.pos_y + s_top,
-                                                                m_pixbuf_bkmk->get_width(), height, Gdk::RGB_DITHER_NONE, 0, 0 );
+                    if( height > 0 ) {
+#if GTKMM_CHECK_VERSION(2,22,0)
+                        cairo_t* cr = cairo_create( m_backscreen.get() );
+                        cairo_rectangle( cr, 1.0, y - ci.pos_y + s_top, m_pixbuf_bkmk->get_width(), height );
+                        cairo_clip( cr );
+                        gdk_cairo_set_source_pixbuf( cr, m_pixbuf_bkmk->gobj(), 1.0, y - ci.pos_y + s_top );
+                        cairo_paint( cr );
+                        cairo_destroy( cr );
+#else
+                        m_backscreen->draw_pixbuf( m_gc, m_pixbuf_bkmk,
+                                                   0, s_top, 1, y - ci.pos_y + s_top,
+                                                   m_pixbuf_bkmk->get_width(), height, Gdk::RGB_DITHER_NONE, 0, 0 );
+#endif
+                    }
                     y += height_bkmk;
                 }
 
@@ -2161,9 +2285,20 @@ bool DrawAreaBase::draw_one_node( LAYOUT* layout, const CLIPINFO& ci )
                         const int s_bottom = MIN( height_post, ci.lower - y );
                         const int height = s_bottom - s_top;
 
-                        if( height > 0 ) m_backscreen->draw_pixbuf( m_gc, m_pixbuf_post,
-                                                                    0, s_top, 1, y - ci.pos_y + s_top,
-                                                                    m_pixbuf_post->get_width(), height, Gdk::RGB_DITHER_NONE, 0, 0 );
+                        if( height > 0 ) {
+#if GTKMM_CHECK_VERSION(2,22,0)
+                            cairo_t* cr = cairo_create( m_backscreen.get() );
+                            cairo_rectangle( cr, 1.0, y - ci.pos_y + s_top, m_pixbuf_post->get_width(), height );
+                            cairo_clip( cr );
+                            gdk_cairo_set_source_pixbuf( cr, m_pixbuf_post->gobj(), 1.0, y - ci.pos_y + s_top );
+                            cairo_paint( cr );
+                            cairo_destroy( cr );
+#else
+                            m_backscreen->draw_pixbuf( m_gc, m_pixbuf_post,
+                                                       0, s_top, 1, y - ci.pos_y + s_top,
+                                                       m_pixbuf_post->get_width(), height, Gdk::RGB_DITHER_NONE, 0, 0 );
+#endif
+                        }
                         y += height_post;
                     }
 
@@ -2179,9 +2314,20 @@ bool DrawAreaBase::draw_one_node( LAYOUT* layout, const CLIPINFO& ci )
                         const int s_bottom = MIN( height_refer_post, ci.lower - y );
                         const int height = s_bottom - s_top;
 
-                        if( height > 0 ) m_backscreen->draw_pixbuf( m_gc, m_pixbuf_refer_post,
-                                                                    0, s_top, 1, y - ci.pos_y + s_top,
-                                                                    m_pixbuf_refer_post->get_width(), height, Gdk::RGB_DITHER_NONE, 0, 0 );
+                        if( height > 0 ) {
+#if GTKMM_CHECK_VERSION(2,22,0)
+                            cairo_t* cr = cairo_create( m_backscreen.get() );
+                            cairo_rectangle( cr, 1.0, y - ci.pos_y + s_top, m_pixbuf_refer_post->get_width(), height );
+                            cairo_clip( cr );
+                            gdk_cairo_set_source_pixbuf( cr, m_pixbuf_refer_post->gobj(), 1.0, y - ci.pos_y + s_top );
+                            cairo_paint( cr );
+                            cairo_destroy( cr );
+#else
+                            m_backscreen->draw_pixbuf( m_gc, m_pixbuf_refer_post,
+                                                       0, s_top, 1, y - ci.pos_y + s_top,
+                                                       m_pixbuf_refer_post->get_width(), height, Gdk::RGB_DITHER_NONE, 0, 0 );
+#endif
+                        }
                         y += height_refer_post;
                     }
                 }
@@ -2208,8 +2354,18 @@ bool DrawAreaBase::draw_one_node( LAYOUT* layout, const CLIPINFO& ci )
                 const int x = layout->rect->x;
                 const int y = layout->rect->y - ci.pos_y;
                 const int color_text = get_colorid_text();
+#if GTKMM_CHECK_VERSION(2,22,0)
+                cairo_t* cr = cairo_create( m_backscreen.get() );
+                gdk_cairo_set_source_color( cr, m_color[ color_text ].gobj() );
+                cairo_set_line_width( cr, 1.0 );
+                cairo_move_to( cr, x, y );
+                cairo_line_to( cr, x + layout->rect->width - 1.0, y );
+                cairo_stroke( cr );
+                cairo_destroy( cr );
+#else
                 m_gc->set_foreground( m_color[ color_text ] );
                 m_backscreen->draw_line( m_gc, x, y, x + layout->rect->width - 1, y );
+#endif
             }
             break;
 
@@ -2271,32 +2427,74 @@ void DrawAreaBase::draw_div( LAYOUT* layout_div, const CLIPINFO& ci )
 
     // 背景
     if( bg_color >= 0 ){
+#if GTKMM_CHECK_VERSION(2,22,0)
+        cairo_t* cr = cairo_create( m_backscreen.get() );
+        gdk_cairo_set_source_color( cr, m_color[ bg_color ].gobj() );
+        cairo_rectangle( cr, layout_div->rect->x, y_div - ci.pos_y, layout_div->rect->width, height_div );
+        cairo_fill( cr );
+        cairo_destroy( cr );
+#else
         m_gc->set_foreground( m_color[ bg_color ] );
         m_backscreen->draw_rectangle( m_gc, true, layout_div->rect->x, y_div - ci.pos_y, layout_div->rect->width, height_div );
+#endif
     }
 
     // left
     if( border_style == CORE::BORDER_SOLID && border_left_color >= 0 && border_left ){
+#if GTKMM_CHECK_VERSION(2,22,0)
+        cairo_t* cr = cairo_create( m_backscreen.get() );
+        gdk_cairo_set_source_color( cr, m_color[ border_left_color ].gobj() );
+        cairo_rectangle( cr, layout_div->rect->x, y_div - ci.pos_y, border_left, height_div );
+        cairo_fill( cr );
+        cairo_destroy( cr );
+#else
         m_gc->set_foreground( m_color[ border_left_color ] );
         m_backscreen->draw_rectangle( m_gc, true, layout_div->rect->x, y_div - ci.pos_y, border_left, height_div );
+#endif
     }
 
     // right
     if( border_style == CORE::BORDER_SOLID && border_right_color >= 0 && border_right ){
+#if GTKMM_CHECK_VERSION(2,22,0)
+        cairo_t* cr = cairo_create( m_backscreen.get() );
+        gdk_cairo_set_source_color( cr, m_color[ border_right_color ].gobj() );
+        cairo_rectangle( cr, layout_div->rect->x + layout_div->rect->width - border_right, y_div - ci.pos_y,
+                         border_right, height_div );
+        cairo_fill( cr );
+        cairo_destroy( cr );
+#else
         m_gc->set_foreground( m_color[ border_right_color ] );
         m_backscreen->draw_rectangle( m_gc, true, layout_div->rect->x + layout_div->rect->width - border_right, y_div - ci.pos_y, border_right, height_div );
+#endif
     }
 
     // top
     if( border_style == CORE::BORDER_SOLID && border_top_color >= 0 && border_top ){
+#if GTKMM_CHECK_VERSION(2,22,0)
+        cairo_t* cr = cairo_create( m_backscreen.get() );
+        gdk_cairo_set_source_color( cr, m_color[ border_top_color ].gobj() );
+        cairo_rectangle( cr, layout_div->rect->x, y_div - ci.pos_y, layout_div->rect->width, border_top );
+        cairo_fill( cr );
+        cairo_destroy( cr );
+#else
         m_gc->set_foreground( m_color[ border_top_color ] );
         m_backscreen->draw_rectangle( m_gc, true, layout_div->rect->x, y_div - ci.pos_y, layout_div->rect->width, border_top );
+#endif
     }
 
     // bottom
     if( border_style == CORE::BORDER_SOLID && border_bottom_color >= 0 && border_bottom ){
+#if GTKMM_CHECK_VERSION(2,22,0)
+        cairo_t* cr = cairo_create( m_backscreen.get() );
+        gdk_cairo_set_source_color( cr, m_color[ border_bottom_color ].gobj() );
+        cairo_rectangle( cr, layout_div->rect->x, y_div + height_div - border_bottom - ci.pos_y,
+                         layout_div->rect->width, border_bottom );
+        cairo_fill( cr );
+        cairo_destroy( cr );
+#else
         m_gc->set_foreground( m_color[ border_bottom_color ] );
         m_backscreen->draw_rectangle( m_gc, true, layout_div->rect->x, y_div + height_div - border_bottom - ci.pos_y, layout_div->rect->width, border_bottom );
+#endif
     }
 }
 
@@ -2342,15 +2540,34 @@ void DrawAreaBase::draw_marker()
     // exec_draw_screen() 参照
     if( m_scroll_window ){
 
+#if GTKMM_CHECK_VERSION(2,22,0)
+        cairo_t* cr = cairo_create( m_back_marker.get() );
+        cairo_rectangle( cr, 0.0, 0.0, m_clip_marker.width, m_clip_marker.height );
+        cairo_clip( cr );
+        cairo_set_source_surface( cr, cairo_get_target( m_cr.get() ), -m_clip_marker.x, -m_clip_marker.y );
+        cairo_paint( cr );
+        cairo_destroy( cr );
+#else
         // [gtkmm <= 2.8] Gdk::GC::set_clip_rectangle( Gdk::Rectangle& rectangle )
         // Gdk::GC::set_clip_rectangle( const Gdk::Rectangle& rectangle )
         Gdk::Rectangle rect_marker( 0, 0, m_clip_marker.width, m_clip_marker.height );
         m_gc->set_clip_rectangle( rect_marker );
         m_back_marker->draw_drawable( m_gc, m_window, m_clip_marker.x, m_clip_marker.y,
                                       0, 0, m_clip_marker.width, m_clip_marker.height );
+#endif
         m_ready_back_marker = true;
     }
 
+#if GTKMM_CHECK_VERSION(2,22,0)
+    const double r = AUTOSCR_CIRCLE / 2.0;
+    cairo_save( m_cr.get() );
+    cairo_rectangle( m_cr.get(), m_clip_marker.x, m_clip_marker.y, m_clip_marker.width, m_clip_marker.height );
+    cairo_clip( m_cr.get() );
+    gdk_cairo_set_source_color( m_cr.get(), m_color[ COLOR_MARKER ].gobj() );
+    cairo_arc( m_cr.get(), x_marker + r, y_marker + r, r - 1.0, 0.0, 2.0 * M_PI );
+    cairo_stroke( m_cr.get() );
+    cairo_restore( m_cr.get() );
+#else
     // [gtkmm <= 2.8] Gdk::GC::set_clip_rectangle( Gdk::Rectangle& rectangle )
     // Gdk::GC::set_clip_rectangle( const Gdk::Rectangle& rectangle )
     Gdk::Rectangle rect_window( m_clip_marker.x, m_clip_marker.y, m_clip_marker.width, m_clip_marker.height );
@@ -2359,6 +2576,7 @@ void DrawAreaBase::draw_marker()
     m_window->draw_arc( m_gc, false,
                         x_marker, y_marker, AUTOSCR_CIRCLE-1, AUTOSCR_CIRCLE-1,
                         0, 360 * 64 );
+#endif
 }
 
 
@@ -2374,20 +2592,46 @@ void DrawAreaBase::draw_frame()
 
     if( m_scroll_window ){
 
+#if GTKMM_CHECK_VERSION(2,22,0)
+        cairo_surface_t* borrowed_sf = cairo_get_target( m_cr.get() );
+        cairo_t* cr = cairo_create( m_back_frame_top.get() );
+        cairo_rectangle( cr, 0.0, 0.0, width_win, WIDTH_FRAME );
+        cairo_clip( cr );
+        cairo_set_source_surface( cr, borrowed_sf, 0.0, 0.0 );
+        cairo_paint( cr );
+        cairo_destroy( cr );
+
+        cr = cairo_create( m_back_frame_bottom.get() );
+        cairo_rectangle( cr, 0.0, 0.0, width_win, WIDTH_FRAME );
+        cairo_clip( cr );
+        cairo_set_source_surface( cr, borrowed_sf, 0.0, WIDTH_FRAME - height_win );
+        cairo_paint( cr );
+        cairo_destroy( cr );
+#else
         // [gtkmm <= 2.8] Gdk::GC::set_clip_rectangle( Gdk::Rectangle& rectangle )
         // Gdk::GC::set_clip_rectangle( const Gdk::Rectangle& rectangle )
         Gdk::Rectangle rect_frame( 0, 0, width_win, WIDTH_FRAME * 2 );
         m_gc->set_clip_rectangle( rect_frame );
         m_back_frame->draw_drawable( m_gc, m_window, 0, 0, 0, 0, width_win, WIDTH_FRAME );
         m_back_frame->draw_drawable( m_gc, m_window, 0, height_win - WIDTH_FRAME, 0, WIDTH_FRAME, width_win, WIDTH_FRAME );
+#endif
         m_ready_back_frame = true;
     }
 
+#if GTKMM_CHECK_VERSION(2,22,0)
+    cairo_save( m_cr.get() );
+    gdk_cairo_set_source_color( m_cr.get(), m_color[ COLOR_FRAME ].gobj() );
+    cairo_set_line_width( m_cr.get(), 2.0 );
+    cairo_rectangle( m_cr.get(), 0.0, 0.0, width_win, height_win );
+    cairo_stroke( m_cr.get() );
+    cairo_restore( m_cr.get() );
+#else
     Gdk::Rectangle rect_clip( 0, 0, width_win, height_win );
     m_gc->set_clip_rectangle( rect_clip );
 
     m_gc->set_foreground( m_color[ COLOR_FRAME ] );
     m_window->draw_rectangle( m_gc, false, WIDTH_FRAME-1, WIDTH_FRAME-1, width_win-WIDTH_FRAME, height_win-WIDTH_FRAME );
+#endif
 }
 
 
@@ -2644,18 +2888,45 @@ const bool DrawAreaBase::draw_one_img_node( LAYOUT* layout, const CLIPINFO& ci )
 
                         Glib::RefPtr< Gdk::Pixbuf > pixbuf2;
                         pixbuf2 = pixbuf->scale_simple( moswidth, mosheight, Gdk::INTERP_NEAREST );
-                        m_backscreen->draw_pixbuf( m_gc,
-                                                   pixbuf2->scale_simple( pixbuf->get_width(), pixbuf->get_height(), Gdk::INTERP_NEAREST ),
-                                                   0, s_top, rect->x + 1, ( rect->y + 1 ) - ci.pos_y + s_top,
-                                                   pixbuf->get_width(), height, Gdk::RGB_DITHER_NONE, 0, 0 );
+#if GTKMM_CHECK_VERSION(2,22,0)
+                        cairo_t* cr = cairo_create( m_backscreen.get() );
+                        cairo_rectangle( cr, rect->x + 1.0, ( rect->y + 1.0 ) - ci.pos_y + s_top,
+                                         pixbuf->get_width(), height );
+                        cairo_clip( cr );
+                        gdk_cairo_set_source_pixbuf(
+                            cr,
+                            pixbuf2
+                                ->scale_simple( pixbuf->get_width(), pixbuf->get_height(), Gdk::INTERP_NEAREST )
+                                ->gobj(),
+                            rect->x + 1.0, ( rect->y + 1.0 ) - ci.pos_y + s_top );
+                        cairo_paint( cr );
+                        cairo_destroy( cr );
+#else
+                        m_backscreen->draw_pixbuf(
+                            m_gc,
+                            pixbuf2->scale_simple( pixbuf->get_width(), pixbuf->get_height(), Gdk::INTERP_NEAREST ),
+                            0, s_top, rect->x + 1, ( rect->y + 1 ) - ci.pos_y + s_top,
+                            pixbuf->get_width(), height, Gdk::RGB_DITHER_NONE, 0, 0 );
+#endif
                     }
                 }
 
                 // 通常
                 else{
+#if GTKMM_CHECK_VERSION(2,22,0)
+                    cairo_t* cr = cairo_create( m_backscreen.get() );
+                    cairo_rectangle( cr, rect->x + 1.0, ( rect->y + 1.0 ) - ci.pos_y + s_top,
+                                     pixbuf->get_width(), height );
+                    cairo_clip( cr );
+                    gdk_cairo_set_source_pixbuf( cr, pixbuf->gobj(),
+                                                 rect->x + 1.0, ( rect->y + 1.0 ) - ci.pos_y + s_top );
+                    cairo_paint( cr );
+                    cairo_destroy( cr );
+#else
                     m_backscreen->draw_pixbuf( m_gc, pixbuf,
                                                0, s_top, rect->x + 1, ( rect->y + 1 ) - ci.pos_y + s_top,
                                                pixbuf->get_width(), height, Gdk::RGB_DITHER_NONE, 0, 0 );
+#endif
                 }
 
 
@@ -2666,9 +2937,19 @@ const bool DrawAreaBase::draw_one_img_node( LAYOUT* layout, const CLIPINFO& ci )
     }
 
     // 枠の描画
+#if GTKMM_CHECK_VERSION(2,22,0)
+    {
+        cairo_t* cr = cairo_create( m_backscreen.get() );
+        gdk_cairo_set_source_color( cr, m_color[ color ].gobj() );
+        cairo_rectangle( cr, rect->x, rect->y - ci.pos_y, rect->width, rect->height );
+        cairo_stroke( cr );
+        cairo_destroy( cr );
+    }
+#else
     // !! draw_rectangle()の filled を false にすると、1 pixel 幅と高さが大きくなるのに注意 !!
     m_gc->set_foreground( m_color[ color ] );
     m_backscreen->draw_rectangle( m_gc, false, rect->x , rect->y  - ci.pos_y, rect->width -1, rect->height -1 );
+#endif
 
     // 右上のアイコン
     if( code != HTTP_OK || img->is_loading() ){
@@ -2676,7 +2957,15 @@ const bool DrawAreaBase::draw_one_img_node( LAYOUT* layout, const CLIPINFO& ci )
         const int y_tmp = rect->y + rect->height / 10 + 1;
         const int width_tmp = rect->width / 4;
         const int height_tmp = rect->width / 4;
+#if GTKMM_CHECK_VERSION(2,22,0)
+        cairo_t* cr = cairo_create( m_backscreen.get() );
+        gdk_cairo_set_source_color( cr, m_color[ color ].gobj() );
+        cairo_rectangle( cr, x_tmp, y_tmp - ci.pos_y, width_tmp, height_tmp );
+        cairo_fill( cr );
+        cairo_destroy( cr );
+#else
         m_backscreen->draw_rectangle( m_gc, true, x_tmp, y_tmp - ci.pos_y, width_tmp, height_tmp );
+#endif
     }
 
 #ifdef _DEBUG
@@ -2778,16 +3067,29 @@ void DrawAreaBase::draw_string( LAYOUT* node, const CLIPINFO& ci,
 
             assert( m_context );
 
+#if GTKMM_CHECK_VERSION(2,22,0)
+            cairo_t* text_cr = cairo_create( m_backscreen.get() );
+            gdk_cairo_set_source_color( text_cr, m_color[ color_back ].gobj() );
+            cairo_rectangle( text_cr, x, y, width_line, m_font->height );
+            cairo_fill( text_cr );
+
+            gdk_cairo_set_source_color( text_cr, m_color[ color ].gobj() );
+#else
             m_gc->set_foreground( m_color[ color_back ] );
             m_backscreen->draw_rectangle( m_gc, true, x, y, width_line, m_font->height );
 
             m_gc->set_foreground( m_color[ color ] );
+#endif
 
             Pango::AttrList attr;
             std::string text = std::string( node->text + pos_start, n_byte );
             std::list< Pango::Item > list_item = m_context->itemize( text, attr );
 
+#if GTKMM_CHECK_VERSION(2,22,0)
+            Glib::RefPtr< Pango::Font > font;
+#else
             Glib::RefPtr< const Pango::Font > font;
+#endif
             Pango::GlyphString grl;
             Pango::Rectangle pango_rect;
 
@@ -2800,8 +3102,17 @@ void DrawAreaBase::draw_string( LAYOUT* node, const CLIPINFO& ci,
                 pango_rect = grl.get_logical_extents( font );
                 int width = PANGO_PIXELS( pango_rect.get_width() );
 
+#if GTKMM_CHECK_VERSION(2,22,0)
+                cairo_move_to( text_cr, x, y + m_font->ascent );
+                pango_cairo_show_glyph_string( text_cr, font->gobj(), grl.gobj() );
+                if( node->bold ) {
+                    cairo_move_to( text_cr, x + 1.0, y + m_font->ascent );
+                    pango_cairo_show_glyph_string( text_cr, font->gobj(), grl.gobj() );
+                }
+#else
                 m_backscreen->draw_glyphs( m_gc, font, x, y + m_font->ascent, grl );
                 if( node->bold ) m_backscreen->draw_glyphs( m_gc, font, x +1, y + m_font->ascent, grl );
+#endif
                 x += width;
             }
 
@@ -2812,10 +3123,20 @@ void DrawAreaBase::draw_string( LAYOUT* node, const CLIPINFO& ci,
 
             // リンクの時は下線を引く
             if( node->link && CONFIG::get_draw_underline() ){
-
+#if GTKMM_CHECK_VERSION(2,22,0)
+                gdk_cairo_set_source_color( text_cr, m_color[ color ].gobj() );
+                cairo_set_line_width( text_cr, 1.0 );
+                cairo_move_to( text_cr, xx, y + m_font->underline_pos );
+                cairo_line_to( text_cr, xx + width_line, y + m_font->underline_pos );
+                cairo_stroke( text_cr );
+#else
                 m_gc->set_foreground( m_color[ color ] );
                 m_backscreen->draw_line( m_gc, xx, y + m_font->underline_pos, xx + width_line, y + m_font->underline_pos );
+#endif
             }
+#if GTKMM_CHECK_VERSION(2,22,0)
+            cairo_destroy( text_cr );
+#endif
         }
 
         if( rect->end ) break;
@@ -4669,6 +4990,12 @@ bool DrawAreaBase::slot_expose_event( GdkEventExpose* event )
               << std::endl;
 #endif
 
+#if GTKMM_CHECK_VERSION(2,22,0)
+    // exposeイベントから抜ける前にm_cr.reset()を呼び出して破棄する必要がある
+    // ローカル変数やスコープガードなどを使用して安全性を高めるべきか
+    m_cr.reset( gdk_cairo_create( m_window->gobj() ) );
+#endif
+
     // draw_screen からの呼び出し
     if(  m_drawinfo.draw  ){
 
@@ -4687,11 +5014,20 @@ bool DrawAreaBase::slot_expose_event( GdkEventExpose* event )
         std::cout << "copy from backscreen\n";
 #endif
 
+#if GTKMM_CHECK_VERSION(2,22,0)
+        cairo_save( m_cr.get() );
+        cairo_rectangle( m_cr.get(), x, y, width, height );
+        cairo_clip( m_cr.get() );
+        cairo_set_source_surface( m_cr.get(), m_backscreen.get(), x, y );
+        cairo_paint( m_cr.get() );
+        cairo_restore( m_cr.get() );
+#else
         // [gtkmm <= 2.8] Gdk::GC::set_clip_rectangle( Gdk::Rectangle& rectangle )
         // Gdk::GC::set_clip_rectangle( const Gdk::Rectangle& rectangle )
         Gdk::Rectangle rect( x, y, width, height );
         m_gc->set_clip_rectangle( rect );
         m_window->draw_drawable( m_gc, m_backscreen, x, y, x, y, width, height );
+#endif
 
         // オートスクロールマーカと枠の描画
         draw_marker();
@@ -4705,8 +5041,17 @@ bool DrawAreaBase::slot_expose_event( GdkEventExpose* event )
         std::cout << "clear window\n";
 #endif
 
+#if GTKMM_CHECK_VERSION(2,22,0)
+        cairo_save( m_cr.get() );
+        gdk_cairo_set_source_color( m_cr.get(), m_color[ get_colorid_back() ].gobj() );
+        cairo_fill( m_cr.get() );
+        cairo_restore( m_cr.get() );
+
+        m_cr.reset();
+#else
         m_window->set_background( m_color[ get_colorid_back() ] );
         m_window->clear();
+#endif
         return false;
     }
 
@@ -4718,6 +5063,9 @@ bool DrawAreaBase::slot_expose_event( GdkEventExpose* event )
         exec_draw_screen( y, height );
     }
 
+#if GTKMM_CHECK_VERSION(2,22,0)
+    m_cr.reset();
+#endif
     return true;
 }
 
@@ -4801,13 +5149,20 @@ void DrawAreaBase::slot_realize()
     m_window = m_view.get_window();
     assert( m_window );
 
+#if !GTKMM_CHECK_VERSION(2,22,0)
     m_gc = Gdk::GC::create( m_window );
     assert( m_gc );
+#endif
 
     // 色初期化
     init_color();
 
+#if GTKMM_CHECK_VERSION(2,22,0)
+    m_back_marker.reset( gdk_window_create_similar_surface(
+        m_window->gobj(), CAIRO_CONTENT_COLOR, AUTOSCR_CIRCLE, AUTOSCR_CIRCLE ) );
+#else
     m_back_marker = Gdk::Pixmap::create( m_window, AUTOSCR_CIRCLE, AUTOSCR_CIRCLE );
+#endif
     assert( m_back_marker );
 
     exec_layout();

--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -1953,18 +1953,7 @@ void DrawAreaBase::exec_draw_screen( const int y_redraw, const int height_redraw
     }
 
     // バックスクリーンの背景クリア
-#if GTKMM_CHECK_VERSION(2,22,0)
-    {
-        cairo_t* cr = cairo_create( m_backscreen.get() );
-        gdk_cairo_set_source_color( cr, m_color[ get_colorid_back() ].gobj() );
-        cairo_rectangle( cr, 0.0, y_screen, width_view, height_screen );
-        cairo_fill( cr );
-        cairo_destroy( cr );
-    }
-#else
-    m_gc->set_foreground( m_color[ get_colorid_back() ] );
-    m_backscreen->draw_rectangle( m_gc, true, 0, y_screen, width_view, height_screen );
-#endif
+    fill_backscreen( m_color[ get_colorid_back() ], 0, y_screen, width_view, height_screen );
 
     // 描画ループ
     CLIPINFO ci = { width_view, pos_y, upper, lower }; // 描画領域
@@ -2427,74 +2416,34 @@ void DrawAreaBase::draw_div( LAYOUT* layout_div, const CLIPINFO& ci )
 
     // 背景
     if( bg_color >= 0 ){
-#if GTKMM_CHECK_VERSION(2,22,0)
-        cairo_t* cr = cairo_create( m_backscreen.get() );
-        gdk_cairo_set_source_color( cr, m_color[ bg_color ].gobj() );
-        cairo_rectangle( cr, layout_div->rect->x, y_div - ci.pos_y, layout_div->rect->width, height_div );
-        cairo_fill( cr );
-        cairo_destroy( cr );
-#else
-        m_gc->set_foreground( m_color[ bg_color ] );
-        m_backscreen->draw_rectangle( m_gc, true, layout_div->rect->x, y_div - ci.pos_y, layout_div->rect->width, height_div );
-#endif
+        fill_backscreen( m_color[ bg_color ], layout_div->rect->x, y_div - ci.pos_y,
+                         layout_div->rect->width, height_div );
     }
 
     // left
     if( border_style == CORE::BORDER_SOLID && border_left_color >= 0 && border_left ){
-#if GTKMM_CHECK_VERSION(2,22,0)
-        cairo_t* cr = cairo_create( m_backscreen.get() );
-        gdk_cairo_set_source_color( cr, m_color[ border_left_color ].gobj() );
-        cairo_rectangle( cr, layout_div->rect->x, y_div - ci.pos_y, border_left, height_div );
-        cairo_fill( cr );
-        cairo_destroy( cr );
-#else
-        m_gc->set_foreground( m_color[ border_left_color ] );
-        m_backscreen->draw_rectangle( m_gc, true, layout_div->rect->x, y_div - ci.pos_y, border_left, height_div );
-#endif
+        fill_backscreen( m_color[ border_left_color ], layout_div->rect->x, y_div - ci.pos_y,
+                         border_left, height_div );
     }
 
     // right
     if( border_style == CORE::BORDER_SOLID && border_right_color >= 0 && border_right ){
-#if GTKMM_CHECK_VERSION(2,22,0)
-        cairo_t* cr = cairo_create( m_backscreen.get() );
-        gdk_cairo_set_source_color( cr, m_color[ border_right_color ].gobj() );
-        cairo_rectangle( cr, layout_div->rect->x + layout_div->rect->width - border_right, y_div - ci.pos_y,
+        fill_backscreen( m_color[ border_right_color ],
+                         layout_div->rect->x + layout_div->rect->width - border_right, y_div - ci.pos_y,
                          border_right, height_div );
-        cairo_fill( cr );
-        cairo_destroy( cr );
-#else
-        m_gc->set_foreground( m_color[ border_right_color ] );
-        m_backscreen->draw_rectangle( m_gc, true, layout_div->rect->x + layout_div->rect->width - border_right, y_div - ci.pos_y, border_right, height_div );
-#endif
     }
 
     // top
     if( border_style == CORE::BORDER_SOLID && border_top_color >= 0 && border_top ){
-#if GTKMM_CHECK_VERSION(2,22,0)
-        cairo_t* cr = cairo_create( m_backscreen.get() );
-        gdk_cairo_set_source_color( cr, m_color[ border_top_color ].gobj() );
-        cairo_rectangle( cr, layout_div->rect->x, y_div - ci.pos_y, layout_div->rect->width, border_top );
-        cairo_fill( cr );
-        cairo_destroy( cr );
-#else
-        m_gc->set_foreground( m_color[ border_top_color ] );
-        m_backscreen->draw_rectangle( m_gc, true, layout_div->rect->x, y_div - ci.pos_y, layout_div->rect->width, border_top );
-#endif
+        fill_backscreen( m_color[ border_top_color ], layout_div->rect->x, y_div - ci.pos_y,
+                         layout_div->rect->width, border_top );
     }
 
     // bottom
     if( border_style == CORE::BORDER_SOLID && border_bottom_color >= 0 && border_bottom ){
-#if GTKMM_CHECK_VERSION(2,22,0)
-        cairo_t* cr = cairo_create( m_backscreen.get() );
-        gdk_cairo_set_source_color( cr, m_color[ border_bottom_color ].gobj() );
-        cairo_rectangle( cr, layout_div->rect->x, y_div + height_div - border_bottom - ci.pos_y,
+        fill_backscreen( m_color[ border_bottom_color ],
+                         layout_div->rect->x, y_div + height_div - border_bottom - ci.pos_y,
                          layout_div->rect->width, border_bottom );
-        cairo_fill( cr );
-        cairo_destroy( cr );
-#else
-        m_gc->set_foreground( m_color[ border_bottom_color ] );
-        m_backscreen->draw_rectangle( m_gc, true, layout_div->rect->x, y_div + height_div - border_bottom - ci.pos_y, layout_div->rect->width, border_bottom );
-#endif
     }
 }
 
@@ -2631,6 +2580,24 @@ void DrawAreaBase::draw_frame()
 
     m_gc->set_foreground( m_color[ COLOR_FRAME ] );
     m_window->draw_rectangle( m_gc, false, WIDTH_FRAME-1, WIDTH_FRAME-1, width_win-WIDTH_FRAME, height_win-WIDTH_FRAME );
+#endif
+}
+
+
+//
+// バックスクリーンを矩形で塗りつぶす補助メソッド
+//
+void DrawAreaBase::fill_backscreen( const Gdk::Color& color, int x, int y, int width, int height )
+{
+#if GTKMM_CHECK_VERSION(2,22,0)
+    cairo_t* cr = cairo_create( m_backscreen.get() );
+    gdk_cairo_set_source_color( cr, color.gobj() );
+    cairo_rectangle( cr, x, y, width, height );
+    cairo_fill( cr );
+    cairo_destroy( cr );
+#else
+    m_gc->set_foreground( color );
+    m_backscreen->draw_rectangle( m_gc, true, x, y, width, height );
 #endif
 }
 
@@ -2957,15 +2924,7 @@ const bool DrawAreaBase::draw_one_img_node( LAYOUT* layout, const CLIPINFO& ci )
         const int y_tmp = rect->y + rect->height / 10 + 1;
         const int width_tmp = rect->width / 4;
         const int height_tmp = rect->width / 4;
-#if GTKMM_CHECK_VERSION(2,22,0)
-        cairo_t* cr = cairo_create( m_backscreen.get() );
-        gdk_cairo_set_source_color( cr, m_color[ color ].gobj() );
-        cairo_rectangle( cr, x_tmp, y_tmp - ci.pos_y, width_tmp, height_tmp );
-        cairo_fill( cr );
-        cairo_destroy( cr );
-#else
-        m_backscreen->draw_rectangle( m_gc, true, x_tmp, y_tmp - ci.pos_y, width_tmp, height_tmp );
-#endif
+        fill_backscreen( m_color[ color ], x_tmp, y_tmp - ci.pos_y, width_tmp, height_tmp );
     }
 
 #ifdef _DEBUG
@@ -3095,17 +3054,12 @@ void DrawAreaBase::draw_string( LAYOUT* node, const CLIPINFO& ci,
 
             assert( m_context );
 
+            fill_backscreen( m_color[ color_back ], x, y, width_line, m_font->height );
 #if GTKMM_CHECK_VERSION(2,22,0)
             cairo_t* text_cr = cairo_create( m_backscreen.get() );
-            gdk_cairo_set_source_color( text_cr, m_color[ color_back ].gobj() );
-            cairo_rectangle( text_cr, x, y, width_line, m_font->height );
-            cairo_fill( text_cr );
 
             gdk_cairo_set_source_color( text_cr, m_color[ color ].gobj() );
 #else
-            m_gc->set_foreground( m_color[ color_back ] );
-            m_backscreen->draw_rectangle( m_gc, true, x, y, width_line, m_font->height );
-
             m_gc->set_foreground( m_color[ color ] );
 #endif
 

--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -1731,9 +1731,17 @@ const bool DrawAreaBase::draw_screen( const int y, const int height )
     }
 
     // キューに expose イベントが溜まっている時は全画面再描画
+#if GTKMM_CHECK_VERSION(3,0,0)
+    cairo_region_t* updated = gdk_window_get_update_area( m_window->gobj() );
+#else
     Gdk::Region rg = m_window->get_update_area();
-    if( rg.gobj() ){
+    const bool updated = bool( rg.gobj() );
+#endif
+    if( updated ) {
         redraw_view_force();
+#if GTKMM_CHECK_VERSION(3,0,0)
+        cairo_region_destroy( updated );
+#endif
         return true;
     }
 

--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -1098,7 +1098,8 @@ const bool DrawAreaBase::exec_layout_impl( const bool is_popup, const int offset
     if( ! m_vscrbar && m_height_client > height_view ) create_scrbar();
 
     // adjustment 範囲変更
-    Gtk::Adjustment* adjust = m_vscrbar ? m_vscrbar->get_adjustment(): NULL;
+    auto adjust = m_vscrbar ? m_vscrbar->get_adjustment()
+                            : decltype( m_vscrbar->get_adjustment() )( nullptr );
     if( adjust ){
 
         const double current = adjust->get_value();
@@ -2995,7 +2996,7 @@ void DrawAreaBase::wheelscroll( GdkEventScroll* event )
 
         if( m_vscrbar && ( m_scrollinfo.mode == SCROLL_NOT || m_scrollinfo.mode == SCROLL_NORMAL ) ){
 
-            Gtk::Adjustment* adjust = m_vscrbar->get_adjustment();
+            const auto adjust = m_vscrbar->get_adjustment();
 
             const int current_y = ( int ) adjust->get_value();
             if( event->direction == GDK_SCROLL_UP && current_y == 0 ) return;
@@ -3076,7 +3077,7 @@ void DrawAreaBase::exec_scroll()
 
     // 移動後のスクロール位置を計算
     int y = 0;
-    Gtk::Adjustment* adjust = m_vscrbar->get_adjustment();
+    auto adjust = m_vscrbar->get_adjustment();
     const int current_y = ( int ) adjust->get_value();
 
     switch( m_scrollinfo.mode ){
@@ -3678,7 +3679,7 @@ const int DrawAreaBase::search_move( const bool reverse )
             std::cout << "move to y = " << y << std::endl;
 #endif
 
-            Gtk::Adjustment* adjust = m_vscrbar->get_adjustment();
+            auto adjust = m_vscrbar->get_adjustment();
             if( ( int ) adjust->get_value() > y || ( int ) adjust->get_value() + ( int ) adjust->get_page_size() - m_font->br_size < y ){
 
                 m_cancel_change_adjust = true;

--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -5474,7 +5474,13 @@ void DrawAreaBase::change_cursor( const Gdk::CursorType type )
     if( m_cursor_type != type ){
         m_cursor_type = type;
         if( m_cursor_type == Gdk::ARROW ) m_window->set_cursor();
-        else m_window->set_cursor( Gdk::Cursor( m_cursor_type ) );
+        else {
+#if GTKMM_CHECK_VERSION(3,0,0)
+            m_window->set_cursor( Gdk::Cursor::create( m_cursor_type ) );
+#else
+            m_window->set_cursor( Gdk::Cursor( m_cursor_type ) );
+#endif
+        }
     }
 }
 

--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -383,7 +383,11 @@ void DrawAreaBase::init_font()
     // layoutにフォントをセット
     m_font = &m_defaultfont;
     m_pango_layout->set_font_description( m_font->pfd );
+#if GTKMM_CHECK_VERSION(3,0,0)
+    override_font( m_font->pfd );
+#else
     modify_font( m_font->pfd );
+#endif
 }
 
 
@@ -2702,7 +2706,11 @@ void DrawAreaBase::set_node_font( LAYOUT* layout )
 
         // layoutにフォントをセット
         m_pango_layout->set_font_description( m_font->pfd );
+#if GTKMM_CHECK_VERSION(3,0,0)
+        override_font( m_font->pfd );
+#else
         modify_font( m_font->pfd );
+#endif
     }
 }
 

--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -326,28 +326,47 @@ void DrawAreaBase::init_color()
     const int usrcolor = colors.size();
     m_color.resize( END_COLOR_FOR_THREAD + usrcolor );
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+    Glib::RefPtr< Gtk::StyleContext > context = get_style_context();
+#else
     Glib::RefPtr< Gdk::Colormap > colormap = get_default_colormap();
+#endif
 
     int i = COLOR_FOR_THREAD +1;
     for( ; i < END_COLOR_FOR_THREAD; ++i ){
 
         m_color[ i ] = Gdk::Color( CONFIG::get_color( i ) );
+#if !GTKMM_CHECK_VERSION(3,0,0)
         colormap->alloc_color( m_color[ i ] );
+#endif
     }
 
     // スレビューの選択色でgtkrcの設定を使用
     if( CONFIG::get_use_select_gtkrc() ){
+#if GTKMM_CHECK_VERSION(3,0,0)
+        Gdk::Color color;
+        auto rgba = context->get_color( Gtk::STATE_FLAG_SELECTED );
+        color.set_rgb( rgba.get_red_u(), rgba.get_green_u(), rgba.get_blue_u() );
+        m_color[ COLOR_CHAR_SELECTION ] = color;
+
+        rgba = context->get_background_color( Gtk::STATE_FLAG_SELECTED );
+        color.set_rgb( rgba.get_red_u(), rgba.get_green_u(), rgba.get_blue_u() );
+        m_color[ COLOR_BACK_SELECTION ] = color;
+#else
         m_color[ COLOR_CHAR_SELECTION ] = get_style()->get_text( Gtk::STATE_SELECTED );
         colormap->alloc_color( m_color[ COLOR_CHAR_SELECTION ] );
 
         m_color[ COLOR_BACK_SELECTION ] = get_style()->get_base( Gtk::STATE_SELECTED );
         colormap->alloc_color( m_color[ COLOR_BACK_SELECTION ] );
+#endif // GTKMM_CHECK_VERSION(3,0,0)
     }
 
     std::vector< std::string >::const_iterator it = colors.begin();
     for( ; it != colors.end(); ++it, ++i ){
         m_color[ i ] = Gdk::Color( ( *it ) );
+#if !GTKMM_CHECK_VERSION(3,0,0)
         colormap->alloc_color( m_color[ i ] );
+#endif
     }
 }
 

--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -3055,6 +3055,33 @@ void DrawAreaBase::draw_string( LAYOUT* node, const CLIPINFO& ci,
 
 #ifdef USE_PANGOLAYOUT  // Pango::Layout を使って文字を描画
 
+#if GTKMM_CHECK_VERSION(2,22,0)
+            const Gdk::Color& fg = m_color[ color ];
+            const Gdk::Color& bg = m_color[ color_back ];
+            auto foreground = Pango::Attribute::create_attr_foreground( fg.get_red(), fg.get_green(), fg.get_blue() );
+            auto background = Pango::Attribute::create_attr_background( bg.get_red(), bg.get_green(), bg.get_blue() );
+
+            m_pango_layout->set_text( Glib::ustring( node->text + pos_start, n_ustr ) );
+
+            cairo_t* text_cr = cairo_create( m_backscreen.get() );
+
+            Pango::AttrList attr;
+            attr.insert( foreground );
+            attr.insert( background );
+            m_pango_layout->set_attributes( attr );
+            cairo_move_to( text_cr, x, y );
+            pango_cairo_show_layout( text_cr, m_pango_layout->gobj() );
+
+            // Pango::Weight属性を使うと文字幅が変わりレイアウトが乱れる
+            // そこで文字を重ねて描画することで太字を表示する
+            if( node->bold ) {
+                Pango::AttrList overlapping;
+                overlapping.insert( foreground );
+                m_pango_layout->set_attributes( overlapping );
+                cairo_move_to( text_cr, x + 1.0, y );
+                pango_cairo_show_layout( text_cr, m_pango_layout->gobj() );
+            }
+#else
             m_pango_layout->set_text( Glib::ustring( node->text + pos_start, n_ustr ) );
             m_backscreen->draw_layout( m_gc,x, y, m_pango_layout, m_color[ color ], m_color[ color_back ] );
 
@@ -3062,6 +3089,7 @@ void DrawAreaBase::draw_string( LAYOUT* node, const CLIPINFO& ci,
                 m_gc->set_foreground( m_color[ color ] );
                 m_backscreen->draw_layout( m_gc, x+1, y, m_pango_layout );
             }
+#endif // GTKMM_CHECK_VERSION(2,22,0)
 
 #else // Pango::GlyphString を使って文字を描画
 
@@ -3119,7 +3147,7 @@ void DrawAreaBase::draw_string( LAYOUT* node, const CLIPINFO& ci,
             // 実際のラインの長さ(x - rect->x)とlayout_one_text_node()で計算した
             // 近似値(rect->width)を一致させる ( 応急処置 )
             if( ! byte_to && abs( ( x - rect->x ) - rect->width ) > 2 ) rect->width = x - rect->x;
-#endif
+#endif // USE_PANGOLAYOUT
 
             // リンクの時は下線を引く
             if( node->link && CONFIG::get_draw_underline() ){

--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -200,7 +200,11 @@ void DrawAreaBase::setup( const bool show_abone, const bool show_scrbar, const b
     m_view.signal_leave_notify_event().connect(  sigc::mem_fun( *this, &DrawAreaBase::slot_leave_notify_event ) );
     m_view.signal_realize().connect( sigc::mem_fun( *this, &DrawAreaBase::slot_realize ));
     m_view.signal_configure_event().connect(  sigc::mem_fun( *this, &DrawAreaBase::slot_configure_event ));
+#if GTKMM_CHECK_VERSION(3,0,0)
+    m_view.signal_draw().connect( sigc::mem_fun( *this, &DrawAreaBase::slot_draw ) );
+#else
     m_view.signal_expose_event().connect(  sigc::mem_fun( *this, &DrawAreaBase::slot_expose_event ));
+#endif
     m_view.signal_scroll_event().connect(  sigc::mem_fun( *this, &DrawAreaBase::slot_scroll_event ));
     m_view.signal_button_press_event().connect(  sigc::mem_fun( *this, &DrawAreaBase::slot_button_press_event ));
     m_view.signal_button_release_event().connect(  sigc::mem_fun( *this, &DrawAreaBase::slot_button_release_event ));
@@ -4956,6 +4960,80 @@ void DrawAreaBase::configure_impl()
 //
 // drawarea の再描画イベント
 //
+#if GTKMM_CHECK_VERSION(3,0,0)
+bool DrawAreaBase::slot_draw( const Cairo::RefPtr< Cairo::Context >& cr )
+{
+    double x1, y1, x2, y2;
+    cr->get_clip_extents( x1, y1, x2, y2 );
+    const double width = x2 - x1;
+    const double height = y2 - y1;
+
+    // タブ操作中は再描画しない
+    if( SESSION::is_tab_operating( URL_ARTICLEADMIN ) ) {
+        return true;
+    }
+#ifdef _DEBUG
+    std::cout << "DrawAreaBase::slot_draw"
+              << " y = " << y1 << " height = " << height << " draw_screen = " << m_drawinfo.draw
+              << " url = " << m_url
+              << std::endl;
+#endif
+    // drawイベントから抜ける前にm_cr.release()を呼び出して所有権を放棄する
+    // ローカル変数やスコープガードなどを使用して安全性を高めるべきか
+    m_cr.reset( cr->cobj() );
+
+    // draw_screen からの呼び出し
+    if( m_drawinfo.draw ) {
+#ifdef _DEBUG
+        std::cout << "draw\n";
+#endif
+        m_drawinfo.draw = false;
+        exec_draw_screen( m_drawinfo.y, m_drawinfo.height );
+    }
+    // バックスクリーンに描画済みならコピー
+    else if( y1 >= m_rect_backscreen.y
+             && y2 <= m_rect_backscreen.y + m_rect_backscreen.height ) {
+#ifdef _DEBUG
+        std::cout << "copy from backscreen\n";
+#endif
+        cairo_save( m_cr.get() );
+        cairo_rectangle( m_cr.get(), x1, y1, width, height );
+        cairo_clip( m_cr.get() );
+        cairo_set_source_surface( m_cr.get(), m_backscreen.get(), x1, y1 );
+        cairo_paint( m_cr.get() );
+        cairo_restore( m_cr.get() );
+
+        // オートスクロールマーカと枠の描画
+        draw_marker();
+        draw_frame();
+    }
+    // レイアウトがセットされていない or まだリサイズしていない
+    // ( m_backscreen == NULL )なら画面消去
+    else if( !m_layout_tree->top_header() || !m_backscreen ) {
+#ifdef _DEBUG
+        std::cout << "clear window\n";
+#endif
+        cairo_save( m_cr.get() );
+        gdk_cairo_set_source_color( m_cr.get(), m_color[ get_colorid_back() ].gobj() );
+        cairo_fill( m_cr.get() );
+        cairo_restore( m_cr.get() );
+
+        // シグナルハンドラの引数から借りただけなので所有権を放棄しておく
+        m_cr.release();
+        return false;
+    }
+    // 必要な所だけ再描画
+    else {
+#ifdef _DEBUG
+        std::cout << "expose\n";
+#endif
+        exec_draw_screen( static_cast< int >( y1 ), static_cast< int >( height ) );
+    }
+    // シグナルハンドラの引数から借りただけなので所有権を放棄しておく
+    m_cr.release();
+    return true;
+}
+#else
 bool DrawAreaBase::slot_expose_event( GdkEventExpose* event )
 {
     const int x = event->area.x;
@@ -5051,6 +5129,7 @@ bool DrawAreaBase::slot_expose_event( GdkEventExpose* event )
 #endif
     return true;
 }
+#endif // GTKMM_CHECK_VERSION(3,0,0)
 
 
 

--- a/src/article/drawareabase.h
+++ b/src/article/drawareabase.h
@@ -455,6 +455,9 @@ namespace ARTICLE
         // 枠の描画
         void draw_frame();
 
+        // バックスクリーンを矩形で塗りつぶす補助メソッド
+        void fill_backscreen( const Gdk::Color& color, int x, int y, int width, int height );
+
         // スロット
         void slot_change_adjust();
         bool slot_expose_event( GdkEventExpose* event );

--- a/src/article/drawareabase.h
+++ b/src/article/drawareabase.h
@@ -122,8 +122,15 @@ namespace ARTICLE
 
         // 描画用
         Glib::RefPtr< Gdk::Window > m_window;
+#if GTKMM_CHECK_VERSION(2,22,0)
+        // cairomm 1.12.0 がメモリリークを起こしたので
+        // C API を使うことで問題を回避する
+        std::unique_ptr< cairo_t, void ( * )( cairo_t* ) > m_cr;
+        std::unique_ptr< cairo_surface_t, void ( * )( cairo_surface_t* ) > m_backscreen;
+#else
         Glib::RefPtr< Gdk::GC > m_gc;
         Glib::RefPtr< Gdk::Pixmap > m_backscreen;
+#endif
         Glib::RefPtr< Pango::Layout > m_pango_layout;
         Glib::RefPtr< Pango::Context > m_context;
         RECTANGLE m_rect_backscreen; // バックスクリーンが描画されている範囲
@@ -147,7 +154,13 @@ namespace ARTICLE
 
         // 枠
         bool m_draw_frame;  // 枠を描画する
+#if GTKMM_CHECK_VERSION(2,22,0)
+        // 枠線に隠れる部分のバックアップを分ける
+        std::unique_ptr< cairo_surface_t, void ( * )( cairo_surface_t* ) > m_back_frame_top;
+        std::unique_ptr< cairo_surface_t, void ( * )( cairo_surface_t* ) > m_back_frame_bottom;
+#else
         Glib::RefPtr< Gdk::Pixmap > m_back_frame; // 枠の背景
+#endif
         bool m_ready_back_frame;
 
         // 範囲選択
@@ -181,7 +194,11 @@ namespace ARTICLE
         int m_pre_pos_y; // ひとつ前のスクロールバーの位置。スクロールした時の差分量計算に使用する
         std::vector< int > m_jump_history;  // ジャンプ履歴
         bool m_cancel_change_adjust; // adjust の値変更イベントをキャンセル
+#if GTKMM_CHECK_VERSION(2,22,0)
+        std::unique_ptr< cairo_surface_t, void ( * )( cairo_surface_t* ) > m_back_marker;
+#else
         Glib::RefPtr< Gdk::Pixmap > m_back_marker; // オートスクロールマーカの背景
+#endif
         RECTANGLE m_clip_marker;
         bool m_ready_back_marker;
         time_t m_wait_scroll;  // 処理落ちした時にスクロールにウエイトを入れる

--- a/src/article/drawareabase.h
+++ b/src/article/drawareabase.h
@@ -464,7 +464,11 @@ namespace ARTICLE
 
         // スロット
         void slot_change_adjust();
+#if GTKMM_CHECK_VERSION(3,0,0)
+        bool slot_draw( const Cairo::RefPtr< Cairo::Context >& cr );
+#else
         bool slot_expose_event( GdkEventExpose* event );
+#endif
         bool slot_scroll_event( GdkEventScroll* event );
         bool slot_leave_notify_event( GdkEventCrossing* event );
         bool slot_visibility_notify_event( GdkEventVisibility* event );

--- a/src/article/drawareabase.h
+++ b/src/article/drawareabase.h
@@ -458,6 +458,10 @@ namespace ARTICLE
         // バックスクリーンを矩形で塗りつぶす補助メソッド
         void fill_backscreen( const Gdk::Color& color, int x, int y, int width, int height );
 
+        // Pixbufの内容をバックスクリーンに貼り付ける補助メソッド
+        void paint_backscreen( const Glib::RefPtr< Gdk::Pixbuf >& pixbuf,
+                               int src_x, int src_y, int dest_x, int dest_y, int width, int height );
+
         // スロット
         void slot_change_adjust();
         bool slot_expose_event( GdkEventExpose* event );

--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -590,7 +590,7 @@ void BBSListViewBase::clock_in()
     // 初期化直後など、まだスクロールバーが表示されてない時があるので表示されるまでジャンプしない
     if( m_jump_y != -1 ){
 
-        Gtk::Adjustment* adjust = m_treeview.get_vadjustment();
+        auto adjust = m_treeview.get_vadjustment();
         if( adjust && adjust->get_upper() > m_jump_y ){
 
 #ifdef _DEBUG
@@ -2246,7 +2246,7 @@ void BBSListViewBase::tree2xml( const std::string& root_name )
 
     // 座標
     int y = 0;
-    Gtk::Adjustment* adjust = m_treeview.get_vadjustment();
+    const auto adjust = m_treeview.get_vadjustment();
     if( adjust )
     {
         if( m_jump_y != -1 && adjust->get_upper() > m_jump_y ) y = m_jump_y;

--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -2779,7 +2779,7 @@ void BBSListViewBase::exec_search()
             // 先頭にいるときは最後に戻る
             if( path == GET_PATH( *( m_treestore->children().begin() ) ) ){
 
-                path = GET_PATH( *( m_treestore->children().rbegin() ) );
+                path = GET_PATH( *( std::prev( m_treestore->children().end() ) ) );
                 Gtk::TreePath path_tmp = path;
                 while( m_treeview.get_row( path_tmp ) ){
                     path = path_tmp;
@@ -2954,13 +2954,17 @@ void BBSListViewBase::append_history()
     m_treeview.append_one_row( ( *it_info ).url, ( *it_info ).name, ( *it_info ).type, ( *it_info ).dirid, ( *it_info ).data, path, before, subdir );
 
     // サイズが越えていたら最後を削除
-    while( ( int )m_treestore->children().size() > CONFIG::get_historyview_size() ){
-
-        Gtk::TreeModel::Row row = *( m_treestore->children().rbegin() );
-        m_treestore->erase( row );
+    const Gtk::TreeNodeChildren children = m_treestore->children();
+    const int history_size = CONFIG::get_historyview_size();
+    if( static_cast< int >( children.size() ) > history_size ) {
+        const auto end = children.end();
+        auto it = std::next( children.begin(), history_size );
+        while( it != end ) {
+            it = m_treestore->erase( *it );
 #ifdef _DEBUG
-        std::cout << "erase bottom\n";
+            std::cout << "erase bottom\n";
 #endif
+        }
     }
 
     goto_top();

--- a/src/bbslist/toolbar.cpp
+++ b/src/bbslist/toolbar.cpp
@@ -36,6 +36,9 @@ BBSListToolBar::BBSListToolBar() :
     m_button_toggle.get_button()->set_tooltip_arrow( "ページ切り替え\n\nマウスホイール回転でも切り替え可能" );
 
     m_label.set_alignment( Gtk::ALIGN_START );
+#if GTKMM_CHECK_VERSION(2,6,0)
+    m_label.set_ellipsize( Pango::ELLIPSIZE_END );
+#endif
     std::vector< std::string > menu;
     menu.push_back( ITEM_NAME_BBSLISTVIEW );
     menu.push_back( ITEM_NAME_FAVORITEVIEW );

--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -37,7 +37,6 @@
 
 #include "icons/iconmanager.h"
 
-#include <gtk/gtk.h> // m_liststore->gobj()->sort_column_id = -2
 #include <sstream>
 
 using namespace BOARD;
@@ -503,7 +502,8 @@ const int BoardViewBase::get_row_size()
 //
 void BoardViewBase::unsorted_column()
 {
-    m_liststore->gobj()->sort_column_id = -2;
+    m_liststore->set_sort_column( Gtk::TreeSortable::DEFAULT_UNSORTED_COLUMN_ID,
+                                  Gtk::SortType::SORT_ASCENDING );
 }
 
 

--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -2648,7 +2648,9 @@ void BoardViewBase::exec_search()
     Gtk::TreePath path = m_treeview.get_current_path();;
     if( path.empty() ){
         if( m_search_invert ) path = GET_PATH( *( m_liststore->children().begin() ) );
-        else GET_PATH( *( m_liststore->children().rbegin() ) );
+        else {
+            GET_PATH( *( std::prev( m_liststore->children().end() ) ) );
+        }
     }
 
     Gtk::TreePath path_start = path;
@@ -2675,7 +2677,7 @@ void BoardViewBase::exec_search()
             // 前へ
             if( ! path.prev() ){
                 // 一番後へ
-                path =  GET_PATH( *( m_liststore->children().rbegin() ) );
+                path = GET_PATH( *( std::prev( m_liststore->children().end() ) ) );
             }
         }
 

--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -1624,7 +1624,7 @@ void BoardViewBase::goto_num( const int num, const int )
 //
 void BoardViewBase::scroll_left()
 {
-    Gtk::Adjustment*  hadjust = m_scrwin.get_hadjustment();
+    auto hadjust = m_scrwin.get_hadjustment();
     if( !hadjust ) return;
     hadjust->set_value( MAX( 0,  hadjust->get_value() - hadjust->get_step_increment() ) );
 }
@@ -1635,7 +1635,7 @@ void BoardViewBase::scroll_left()
 //
 void BoardViewBase::scroll_right()
 {
-    Gtk::Adjustment*  hadjust = m_scrwin.get_hadjustment();
+    auto hadjust = m_scrwin.get_hadjustment();
     if( !hadjust ) return;
     hadjust->set_value(  MIN( hadjust->get_upper() - hadjust->get_page_size(),
                               hadjust->get_value() + hadjust->get_step_increment() ) );

--- a/src/board/preference.h
+++ b/src/board/preference.h
@@ -3,11 +3,17 @@
 #ifndef _BOARD_PREFERENCES_H
 #define _BOARD_PREFERENCES_H
 
+#include "gtkmmversion.h"
+
 #include "skeleton/view.h"
 #include "skeleton/prefdiag.h"
 #include "skeleton/editview.h"
 #include "skeleton/label_entry.h"
 #include "skeleton/spinbutton.h"
+
+#if GTKMM_CHECK_VERSION(3,0,0)
+using GtkNotebookPage = Gtk::Widget;
+#endif
 
 namespace BOARD
 {

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -1072,7 +1072,16 @@ const std::list< std::string > CACHE::open_load_diag( Gtk::Window* parent, const
     {
         diag.hide();
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+        // Gtk::FileChooserDialog::get_filenames()の戻り値の
+        // コンテナがstd::vectorに変わったのでとりあえず型変換している
+        // HACK: 周辺の関数をstd::vectorに修正するほうが良いかもしれない
+        std::vector< std::string > filenames = diag.get_filenames();
+        return MISC::recover_path( std::list< std::string >( std::make_move_iterator( filenames.begin() ),
+                                                             std::make_move_iterator( filenames.end() ) ) );
+#else
         return MISC::recover_path( diag.get_filenames() );
+#endif
     }
 
     return std::list< std::string >();

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -1006,25 +1006,45 @@ void CACHE::add_filter_to_diag( Gtk::FileChooserDialog& diag, const int type )
 {
     if( type == FILE_TYPE_ALL ) return;
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+    Glib::RefPtr< Gtk::FileFilter > filter = Gtk::FileFilter::create();
+#else
     Gtk::FileFilter filter;
+#endif
     switch( type ) 
     {
         case FILE_TYPE_TEXT:
+#if GTKMM_CHECK_VERSION(3,0,0)
+            filter->set_name( "全てのテキストファイル" );
+            filter->add_mime_type( "text/plain" );
+#else
             filter.set_name( "全てのテキストファイル" );
             filter.add_mime_type( "text/plain" );
+#endif
             diag.add_filter( filter );
             break;
 
         case FILE_TYPE_DAT:
+#if GTKMM_CHECK_VERSION(3,0,0)
+            filter->set_name( "全てのDATファイル" );
+            filter->add_pattern( "*.dat" );
+#else
             filter.set_name( "全てのDATファイル" );
             filter.add_pattern( "*.dat" );
+#endif
             diag.add_filter( filter );
             break;
     }
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+    Glib::RefPtr< Gtk::FileFilter > all = Gtk::FileFilter::create();
+    all->set_name( "全てのファイル" );
+    all->add_pattern( "*" );
+#else
     Gtk::FileFilter all;
     all.set_name( "全てのファイル" );
     all.add_pattern( "*" );
+#endif
     diag.add_filter( all );
 }
 

--- a/src/config/aboutconfig.cpp
+++ b/src/config/aboutconfig.cpp
@@ -74,6 +74,9 @@ void AboutConfig::pack_widgets()
     get_vbox()->pack_start( m_scrollwin );
 
     set_title( "about:config 高度な設定" );
+#if GTKMM_CHECK_VERSION(3,0,0)
+    set_default_size_raito( 0.666 );
+#endif
     show_all_children();
 
     append_rows();

--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -368,11 +368,15 @@ const int Control::MG_wheel_scroll( const GdkEventScroll* event )
     if( m_wheel_scroll_time && time_tmp < time_cancel ) return control;
     m_wheel_scroll_time = event->time;
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+    Gdk::ModifierType mask = static_cast< Gdk::ModifierType >( event->state );
+#else
     // 押しているボタンは event から取れないので
     // get_pointer()から取る
     int x, y;
     Gdk::ModifierType mask;
     Gdk::Display::get_default()->get_pointer( x, y, mask );
+#endif
 
     int button = 0;
     GdkEventButton ev = GdkEventButton();

--- a/src/control/controlutil.cpp
+++ b/src/control/controlutil.cpp
@@ -137,11 +137,64 @@ const bool CONTROL::is_ascii( const guint keysym )
 }
 
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+static void slot_set_menu_motion( Gtk::Widget& widget )
+{
+    auto item = dynamic_cast< Gtk::MenuItem* >( &widget );
+
+    auto label = dynamic_cast< Gtk::AccelLabel* >( item->get_child() );
+    if( label ) {
+#ifdef _DEBUG
+        std::cout << label->get_text() << std::endl;
+#endif
+        const int id = CONTROL::get_id( label->get_text() );
+        if( id != CONTROL::None ) {
+            const std::string str_label = CONTROL::get_label_with_mnemonic( id );
+            std::string str_motions;
+
+#if GTKMM_CHECK_VERSION(3,6,0)
+            // CONTROL::get_str_motions()を参考に別個対応のidを処理する
+            if( id == CONTROL::PreferenceArticle
+                || id == CONTROL::PreferenceBoard
+                || id == CONTROL::PreferenceImage ) {
+                label->set_accel( GDK_KEY_p, Gdk::CONTROL_MASK | Gdk::SHIFT_MASK );
+                str_motions = CONTROL::get_str_mousemotions( CONTROL::PreferenceView );
+            }
+            else if( id == CONTROL::SaveDat ) {
+                label->set_accel( GDK_KEY_s, Gdk::CONTROL_MASK );
+                str_motions = CONTROL::get_str_mousemotions( CONTROL::Save );
+            }
+            else {
+                const auto key = CONTROL::get_accelkey( id );
+                if( !key.is_null() ) {
+                    label->set_accel( key.get_key(), key.get_mod() );
+                }
+                str_motions = CONTROL::get_str_mousemotions( id );
+            }
+#else
+            // XXX: Gtk::MenuItemにGtk::HBoxを追加する方法は動作しなくなった
+            str_motions = CONTROL::get_str_motions( id );
+#endif // GTKMM_CHECK_VERSION(3,6,0)
+
+            label->set_text_with_mnemonic( str_label + ( str_motions.empty() ? "" : "\t" + str_motions ) );
+        }
+    }
+
+    if( item->has_submenu() ) {
+        CONTROL::set_menu_motion( item->get_submenu() );
+    }
+}
+#endif // GTKMM_CHECK_VERSION(3,0,0)
+
+
 // メニューにショートカットキーやマウスジェスチャを表示
 void CONTROL::set_menu_motion( Gtk::Menu* menu )
 {
     if( !menu ) return;
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+    menu->foreach( &slot_set_menu_motion );
+#else
     Gtk::Menu_Helpers::MenuList& items = menu->items();
     Gtk::Menu_Helpers::MenuList::iterator it_item = items.begin();
     for( ; it_item != items.end(); ++it_item ){
@@ -173,6 +226,7 @@ void CONTROL::set_menu_motion( Gtk::Menu* menu )
 
         if( (*it_item).has_submenu() ) CONTROL::set_menu_motion( (*it_item).get_submenu() );
     }
+#endif // GTKMM_CHECK_VERSION(3,0,0)
 }
 
 

--- a/src/control/keysyms.h
+++ b/src/control/keysyms.h
@@ -5,6 +5,12 @@
 #ifndef _KEYSYMS_H
 #define _KEYSYMS_H
 
+#include "gtkmmversion.h"
+
+#if GTKMM_CHECK_VERSION(3,0,0)
+#include <gdk/gdkkeysyms-compat.h>
+#endif
+
 enum
 {
     MAX_KEYNAME = 64

--- a/src/control/mousekeypref.cpp
+++ b/src/control/mousekeypref.cpp
@@ -419,7 +419,7 @@ void MouseKeyDiag::slot_row_activated( const Gtk::TreeModel::Path& path, Gtk::Tr
 // 行削除
 void MouseKeyDiag::slot_delete()
 {
-    std::list< Gtk::TreeModel::Path > rows = m_treeview.get_selection()->get_selected_rows();
+    std::vector< Gtk::TreeModel::Path > rows = m_treeview.get_selection()->get_selected_rows();
     if( ! rows.size() ) return;
 
     Gtk::TreeModel::Path path = *rows.begin();

--- a/src/control/mousekeypref.cpp
+++ b/src/control/mousekeypref.cpp
@@ -543,6 +543,9 @@ MouseKeyPref::MouseKeyPref( Gtk::Window* parent, const std::string& url, const s
     get_vbox()->pack_start( m_scrollwin );
     get_vbox()->pack_start( m_hbox, Gtk::PACK_SHRINK );
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+    set_default_size_raito( 0.666 );
+#endif
     show_all_children();
     set_title( target + "設定" );
 }

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -1168,7 +1168,15 @@ void Core::run( const bool init, const bool skip_setupdiag )
     // その他設定とwidgetのパッキング
     m_notebook_right.set_show_tabs( false );
     m_notebook_right.set_show_border( false );
+#if GTKMM_CHECK_VERSION(3,12,0)
+    m_notebook_right.set_margin_start( 0 );
+    m_notebook_right.set_margin_end( 0 );
+#elif GTKMM_CHECK_VERSION(3,0,0)
+    m_notebook_right.set_margin_left( 0 );
+    m_notebook_right.set_margin_right( 0 );
+#else
     m_notebook_right.get_style()->set_xthickness( 10 );
+#endif
 
     if( CONFIG::get_open_sidebar_by_click() ) m_hpaned.get_ctrl().set_click_fold( SKELETON::PANE_CLICK_FOLD_PAGE1 );
     m_hpaned.get_ctrl().add_remove1( false, *m_sidebar );

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -136,7 +136,11 @@ Core::Core( JDWinMain& win_main )
     CORE::get_search_manager();
 
     m_vbox_article.signal_realize().connect( sigc::mem_fun(*this, &Core::slot_realize ) );
+#if GTKMM_CHECK_VERSION(3,0,0)
+    m_vbox_article.signal_style_updated().connect( sigc::mem_fun( *this, &Core::slot_style_updated ) );
+#else
     m_vbox_article.signal_style_changed().connect( sigc::mem_fun(*this, &Core::slot_style_changed ) );
+#endif
 }
 
 
@@ -291,14 +295,28 @@ void Core::slot_realize()
     std::cout << "Core::slot_realize\n";
 #endif
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+    slot_style_updated();
+#else
     slot_style_changed( m_vbox_article.get_style() );
+#endif
 }
 
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+// XXX: Gtk::StyleContextにはスタイルを一括コピーする機能がない
+// そこでCore::slot_realize()のコメントを参考に背景色を上書きするロジックにした
+void Core::slot_style_updated()
+{
+    auto rgba = m_vbox_article.get_style_context()->get_background_color();
+    m_notebook_right.override_background_color( rgba, m_vbox_article.get_state_flags() );
+}
+#else
 void Core::slot_style_changed( Glib::RefPtr< Gtk::Style > )
 {
     m_notebook_right.set_style( m_vbox_article.get_style() );
 }
+#endif // GTKMM_CHECK_VERSION(3,0,0)
 
 
 Gtk::Widget* Core::get_toplevel()

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -1087,12 +1087,20 @@ void Core::run( const bool init, const bool skip_setupdiag )
     m_menubar->set_size_request( 0 );
 
     // 履歴メニュー追加
+#if GTKMM_CHECK_VERSION(3,0,0)
+    const auto items = m_menubar->get_children();
+    auto item = dynamic_cast< Gtk::MenuItem* >( *std::next( items.begin(), 2 ) );
+    item->signal_activate().connect( sigc::mem_fun( *this, &Core::slot_activate_historymenu ) );
+
+    Gtk::Menu* submenu = item->get_submenu();
+#else
     Gtk::Menu_Helpers::MenuList& items = m_menubar->items();
     Gtk::Menu_Helpers::MenuList::iterator it_item = items.begin();
     ++it_item; ++it_item;
     (*it_item).signal_activate().connect( sigc::mem_fun( *this, &Core::slot_activate_historymenu ) );
 
     Gtk::Menu* submenu = dynamic_cast< Gtk::Menu* >( (*it_item).get_submenu() );
+#endif // GTKMM_CHECK_VERSION(3,0,0)
 
     submenu->append( *Gtk::manage( new Gtk::SeparatorMenuItem() ) );
 
@@ -1114,6 +1122,13 @@ void Core::run( const bool init, const bool skip_setupdiag )
     submenu->show_all_children();
 
     // メニューにショートカットキーやマウスジェスチャを表示
+#if GTKMM_CHECK_VERSION(3,0,0)
+    m_menubar->foreach( [this]( Gtk::Widget& w ) {
+        auto item = dynamic_cast< Gtk::MenuItem* >( &w );
+        CONTROL::set_menu_motion( item->get_submenu() );
+        item->signal_activate().connect( sigc::mem_fun( *this, &Core::slot_activate_menubar ) );
+    } );
+#else
     items = m_menubar->items();
     it_item = items.begin();
     for( ; it_item != items.end(); ++it_item ){
@@ -1122,6 +1137,7 @@ void Core::run( const bool init, const bool skip_setupdiag )
 
         ( *it_item ).signal_activate().connect( sigc::mem_fun( *this, &Core::slot_activate_menubar ) );
     }
+#endif // GTKMM_CHECK_VERSION(3,0,0)
 
     // ツールバー作成
     create_toolbar();

--- a/src/core.h
+++ b/src/core.h
@@ -7,6 +7,8 @@
 #ifndef _CORE_H
 #define _CORE_H
 
+#include "gtkmmversion.h"
+
 #include <gtkmm.h>
 #include <list>
 #include <string>
@@ -21,6 +23,10 @@
 #include "command_args.h"
 
 class JDWinMain;
+
+#if GTKMM_CHECK_VERSION(3,0,0)
+using GtkNotebookPage = Gtk::Widget;
+#endif
 
 
 namespace BOARD

--- a/src/core.h
+++ b/src/core.h
@@ -148,7 +148,11 @@ namespace CORE
         void set_maintitle();
 
         void slot_realize();
+#if GTKMM_CHECK_VERSION(3,0,0)
+        void slot_style_updated();
+#else
         void slot_style_changed( Glib::RefPtr< Gtk::Style > );
+#endif
 
         void slot_activate_menubar();
         void slot_activate_historymenu();

--- a/src/dbimg/delimgcachediag.cpp
+++ b/src/dbimg/delimgcachediag.cpp
@@ -48,21 +48,40 @@ DelImgCacheDiag::~DelImgCacheDiag()
 }
 
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+bool DelImgCacheDiag::on_draw( const Cairo::RefPtr< Cairo::Context >& cr )
+{
+#ifdef _DEBUG
+    std::cout << "DelImgCacheDiag::on_draw\n";
+#endif
+
+    launch_thread();
+    return Gtk::Dialog::on_draw( cr );
+}
+#else
 bool DelImgCacheDiag::on_expose_event( GdkEventExpose* event )
 {
 #ifdef _DEBUG
     std::cout << "DelImgCacheDiag::on_expose_event\n";
 #endif
 
+    launch_thread();
+    return Gtk::Dialog::on_expose_event( event );
+}
+#endif // GTKMM_CHECK_VERSION(3,0,0)
+
+
+void DelImgCacheDiag::launch_thread()
+{
     // スレッドを起動してキャッシュ削除
-    if( ! m_thread.is_running() ){
+    if( !m_thread.is_running() ) {
         m_stop = false;
-        if( ! m_thread.create( ( STARTFUNC ) launcher, ( void * ) this, JDLIB::NODETACH ) ){
-            MISC::ERRMSG( "DelImgCacheDiag::on_expose_event : could not start thread" );
+        if( !m_thread.create( static_cast< STARTFUNC >( launcher ),
+                              static_cast< void* >( this ),
+                              JDLIB::NODETACH ) ) {
+            MISC::ERRMSG( "DelImgCacheDiag::launch_thread : could not start thread" );
         }
     }
-
-    return Gtk::Dialog::on_expose_event( event );
 }
 
 

--- a/src/dbimg/delimgcachediag.h
+++ b/src/dbimg/delimgcachediag.h
@@ -35,7 +35,11 @@ namespace DBIMG
 
       protected:
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+        virtual bool on_draw( const Cairo::RefPtr< Cairo::Context >& cr ) override;
+#else
         virtual bool on_expose_event( GdkEventExpose* event );
+#endif
 
       private:
 
@@ -43,6 +47,7 @@ namespace DBIMG
         void wait();
         void slot_cancel_clicked();
         time_t get_days( const std::string& path );
+        void launch_thread();
     };
 }
 

--- a/src/fontcolorpref.cpp
+++ b/src/fontcolorpref.cpp
@@ -469,11 +469,11 @@ void FontColorPref::slot_change_color()
 {
     Gtk::TreeModel::Path path;
     Gtk::TreeRow row;
-    
-    std::list< Gtk::TreePath > selection_path = m_treeview_color.get_selection()->get_selected_rows();
+
+    std::vector< Gtk::TreePath > selection_path = m_treeview_color.get_selection()->get_selected_rows();
     if( selection_path.empty() ) return;
 
-    std::list< Gtk::TreePath >::iterator it = selection_path.begin();
+    std::vector< Gtk::TreePath >::iterator it = selection_path.begin();
 
     int colorid = COLOR_NONE;
     if( selection_path.size() == 1 ){
@@ -521,10 +521,10 @@ void FontColorPref::slot_change_color()
 //
 void FontColorPref::slot_reset_color()
 {
-    std::list< Gtk::TreePath > selection_path = m_treeview_color.get_selection()->get_selected_rows();
+    std::vector< Gtk::TreePath > selection_path = m_treeview_color.get_selection()->get_selected_rows();
     if( selection_path.empty() ) return;
 
-    std::list< Gtk::TreePath >::iterator it = selection_path.begin();
+    std::vector< Gtk::TreePath >::iterator it = selection_path.begin();
 
     for( ; it != selection_path.end(); ++it ){
 

--- a/src/fontcolorpref.cpp
+++ b/src/fontcolorpref.cpp
@@ -107,6 +107,9 @@ FontColorPref::FontColorPref( Gtk::Window* parent, const std::string& url )
 #endif
 
     set_title( "フォントと色の詳細設定" );
+#if GTKMM_CHECK_VERSION(3,0,0)
+    set_default_size_raito( 0.5 );
+#endif
     show_all_children();
 }
 

--- a/src/fontcolorpref.cpp
+++ b/src/fontcolorpref.cpp
@@ -98,8 +98,13 @@ FontColorPref::FontColorPref( Gtk::Window* parent, const std::string& url )
 
     m_combo_font.set_active( 0 );
     m_fontbutton.set_font_name( CONFIG::get_fontname( m_font_tbl[ 0 ] ) );
+#if GTKMM_CHECK_VERSION(2,12,0)
+    m_event_font.set_tooltip_text( m_tooltips_font[ 0 ] );
+    m_fontbutton.set_tooltip_text( m_tooltips_font[ 0 ] );
+#else
     m_tooltips.set_tip( m_event_font, m_tooltips_font[ 0 ] );
     m_tooltips.set_tip( m_fontbutton, m_tooltips_font[ 0 ] );
+#endif
 
     set_title( "フォントと色の詳細設定" );
     show_all_children();
@@ -128,7 +133,11 @@ void FontColorPref::pack_widget()
 
     m_checkbutton_font.add_label( "スレビューでフォント幅の近似計算を厳密に行う(_S)", true ),
     m_checkbutton_font.set_active( CONFIG::get_strict_char_width() );
+#if GTKMM_CHECK_VERSION(2,12,0)
+    m_checkbutton_font.set_tooltip_text( WARNING_STRICTCHAR );
+#else
     m_tooltips.set_tip( m_checkbutton_font, WARNING_STRICTCHAR );
+#endif
     m_hbox_checkbutton.pack_start( m_checkbutton_font, Gtk::PACK_SHRINK );
     m_vbox_font.pack_start( m_hbox_checkbutton, Gtk::PACK_SHRINK, mrg/2 );
 
@@ -143,7 +152,12 @@ void FontColorPref::pack_widget()
     m_hbox_space.set_spacing ( mrg );
     m_hbox_space.pack_start( m_label_space, Gtk::PACK_SHRINK );
     m_hbox_space.pack_start( m_spin_space, Gtk::PACK_SHRINK );
-    m_tooltips.set_tip( m_spin_space, "スレビューにおいて行の高さを調節します( 標準は 1 )" );
+    constexpr const char* ss_tip = "スレビューにおいて行の高さを調節します( 標準は 1 )";
+#if GTKMM_CHECK_VERSION(2,12,0)
+    m_spin_space.set_tooltip_text( ss_tip );
+#else
+    m_tooltips.set_tip( m_spin_space, ss_tip );
+#endif
     m_vbox_font.pack_start( m_hbox_space, Gtk::PACK_SHRINK, mrg/2 );
 
     set_activate_entry( m_spin_space );
@@ -159,14 +173,25 @@ void FontColorPref::pack_widget()
     m_hbox_ubar.pack_start( m_label_ubar, Gtk::PACK_SHRINK );
     m_hbox_ubar.pack_start( m_spin_ubar, Gtk::PACK_SHRINK );
     m_vbox_font.pack_start( m_hbox_ubar, Gtk::PACK_SHRINK, mrg/2 );
-    m_tooltips.set_tip( m_spin_ubar, "スレビューにおいてアンカーなどの下線の位置を調節します( 標準は 1 )" );
+    constexpr const char* su_tip = "スレビューにおいてアンカーなどの下線の位置を調節します( 標準は 1 )";
+#if GTKMM_CHECK_VERSION(2,12,0)
+    m_spin_ubar.set_tooltip_text( su_tip );
+#else
+    m_tooltips.set_tip( m_spin_ubar, su_tip );
+#endif
 
     set_activate_entry( m_spin_ubar );
 
     // AAレスと判定する正規表現
     m_label_aafont.set_text( CONFIG::get_regex_res_aa() );
     m_vbox_font.pack_start( m_label_aafont, Gtk::PACK_SHRINK, mrg/2 );
-    m_tooltips.set_tip( m_label_aafont, "この正規表現に一致したレスは、アスキーアートフォントで表示します( 次に開いたスレから有効 )" );
+    constexpr const char* la_tip =
+        "この正規表現に一致したレスは、アスキーアートフォントで表示します( 次に開いたスレから有効 )";
+#if GTKMM_CHECK_VERSION(2,12,0)
+    m_label_aafont.set_tooltip_text( la_tip );
+#else
+    m_tooltips.set_tip( m_label_aafont, la_tip );
+#endif
 
     set_activate_entry( m_label_aafont );
 
@@ -312,8 +337,13 @@ void FontColorPref::slot_combo_font_changed()
 {
     const int num = m_combo_font.get_active_row_number();
     m_fontbutton.set_font_name( CONFIG::get_fontname( m_font_tbl[ num ] ) );
+#if GTKMM_CHECK_VERSION(2,12,0)
+    m_event_font.set_tooltip_text( m_tooltips_font[ num ] );
+    m_fontbutton.set_tooltip_text( m_tooltips_font[ num ] );
+#else
     m_tooltips.set_tip( m_event_font, m_tooltips_font[ num ] );
     m_tooltips.set_tip( m_fontbutton, m_tooltips_font[ num ] );
+#endif
 }
 
 

--- a/src/fontcolorpref.h
+++ b/src/fontcolorpref.h
@@ -37,8 +37,10 @@ namespace CORE
     {
         Gtk::Notebook m_notebook;
 
+#if !GTKMM_CHECK_VERSION(2,12,0)
         // ツールチップ
         Gtk::Tooltips m_tooltips;
+#endif
 
         // フォントの設定
         std::vector< int > m_font_tbl;

--- a/src/icons/iconmanager.cpp
+++ b/src/icons/iconmanager.cpp
@@ -88,7 +88,17 @@ using namespace ICON;
 
 ICON_Manager::ICON_Manager()
 {
+#if GTKMM_CHECK_VERSION(3,0,0)
+    struct Dummy : public Gtk::Image
+    {
+        Glib::RefPtr< Gdk::Pixbuf > render_icon( Gtk::BuiltinStockID stock, Gtk::BuiltinIconSize size )
+        {
+            return render_icon_pixbuf( stock, size );
+        }
+    } m_dummy;
+#else
     Gtk::Image m_dummy;
+#endif
 
     m_list_icons.resize( NUM_ICONS );
 

--- a/src/image/imageadmin.cpp
+++ b/src/image/imageadmin.cpp
@@ -2,6 +2,7 @@
 
 //#define _DEBUG
 #include "jddebug.h"
+#include "gtkmmversion.h"
 
 #include "imageadmin.h"
 #include "imagewin.h"
@@ -838,7 +839,7 @@ void ImageAdmin::switch_img( const std::string& url )
     if( view_icon ) view_icon->set_command( "switch_icon" );
 
     // タブをスクロール
-    Gtk::Adjustment* adjust = m_scrwin.get_hadjustment();
+    auto adjust = m_scrwin.get_hadjustment();
     if( page != -1 && adjust ){
         double pos = adjust->get_value();
         double upper =  m_list_view.size() * ICON_SIZE;
@@ -957,7 +958,7 @@ void ImageAdmin::scroll_tab( int scroll )
     std::cout << "ImageAdmin::scroll_tab " << scroll << std::endl;
 #endif
 
-    Gtk::Adjustment* adjust = m_scrwin.get_hadjustment();
+    auto adjust = m_scrwin.get_hadjustment();
     if( adjust ){
         double pos = adjust->get_value();
         double upper = adjust->get_upper();

--- a/src/image/imageadmin.cpp
+++ b/src/image/imageadmin.cpp
@@ -168,7 +168,11 @@ bool ImageAdmin::empty()
 //
 int ImageAdmin::get_tab_nums()
 {
+#if GTKMM_CHECK_VERSION(3,0,0)
+    return static_cast< int >( m_iconbox.get_children().size() );
+#else
     return m_iconbox.children().size();
+#endif
 }
 
 
@@ -179,11 +183,20 @@ int ImageAdmin::get_tab_nums()
 const std::list< std::string > ImageAdmin::get_URLs()
 {
     std::list< std::string > urls;
+#if GTKMM_CHECK_VERSION(3,0,0)
+    m_iconbox.foreach( [&urls]( Gtk::Widget& w ) {
+        auto view = dynamic_cast< SKELETON::View* >( &w );
+        if( view ) {
+            urls.push_back( view->get_url() );
+        }
+    } );
+#else
     Gtk::Box_Helpers::BoxList::iterator it = m_iconbox.children().begin();
     for(; it !=  m_iconbox.children().end(); ++it ){
         SKELETON::View* view = dynamic_cast< SKELETON::View* >( it->get_widget() );
         if( view ) urls.push_back( view->get_url() );
     }
+#endif // GTKMM_CHECK_VERSION(3,0,0)
 
     return urls;
 }
@@ -198,11 +211,20 @@ const std::list< std::string > ImageAdmin::get_URLs()
 void ImageAdmin::clock_in()
 {
     // アイコンにクロックを送る
+#if GTKMM_CHECK_VERSION(3,0,0)
+    m_iconbox.foreach( []( Gtk::Widget& w ) {
+        auto view = dynamic_cast< SKELETON::View* >( &w );
+        if( view ) {
+            view->clock_in();
+        }
+    } );
+#else
     Gtk::Box_Helpers::BoxList::iterator it = m_iconbox.children().begin();
     for(; it !=  m_iconbox.children().end(); ++it ){
         SKELETON::View* view = dynamic_cast< SKELETON::View* >( it->get_widget() );
         if( view ) view->clock_in();
     }
+#endif // GTKMM_CHECK_VERSION(3,0,0)
 
     // 画像が表示されている場合viewにクロックを回す
     if( SESSION::is_shown_win_img() ){
@@ -356,10 +378,31 @@ void ImageAdmin::open_view( const COMMAND_ARGS& command )
 //
 void ImageAdmin::tab_left( const bool updated )
 {
+    std::string url_to;
+
+#if GTKMM_CHECK_VERSION(3,0,0)
+    const auto widgets = m_iconbox.get_children();
+    if( widgets.size() == 1 ) return;
+
+    const SKELETON::View* const icon = get_current_icon();
+    for( auto&& widget : widgets ) {
+        auto view = dynamic_cast< SKELETON::View* >( widget );
+        if( view ) {
+            if( view == icon ) break;
+            url_to = view->get_url();
+        }
+    }
+    // 一番最後へ戻る
+    if( url_to.empty() ) {
+        auto view = dynamic_cast< SKELETON::View* >( widgets.back() );
+        if( view ) {
+            url_to = view->get_url();
+        }
+    }
+#else // !GTKMM_CHECK_VERSION(3,0,0)
     if( m_iconbox.children().size() == 1 ) return;
 
     SKELETON::View* view;
-    std::string url_to;
     SKELETON::View* icon = get_current_icon();
     Gtk::Box_Helpers::BoxList::iterator it = m_iconbox.children().begin();
     for(; it !=  m_iconbox.children().end(); ++it ){
@@ -376,6 +419,7 @@ void ImageAdmin::tab_left( const bool updated )
         view = dynamic_cast< SKELETON::View* >( (--it)->get_widget() );
         if( view ) url_to = view->get_url();
     }
+#endif // GTKMM_CHECK_VERSION(3,0,0)
 
     if( !url_to.empty() ) switch_img( url_to );
     focus_current_view();
@@ -384,9 +428,24 @@ void ImageAdmin::tab_left( const bool updated )
 
 void ImageAdmin::tab_right( const bool updated )
 {
+    std::string url_to;
+
+#if GTKMM_CHECK_VERSION(3,0,0)
+    const auto widgets = m_iconbox.get_children();
+    if( widgets.size() == 1 ) return;
+
+    auto it = std::find( widgets.begin(), widgets.end(), static_cast< Gtk::Widget* >( get_current_icon() ) );
+    ++it;
+    if( it == widgets.end() ) {
+        it = widgets.begin();
+    }
+    auto view = dynamic_cast< SKELETON::View* >( *it );
+    if( view ) {
+        url_to = view->get_url();
+    }
+#else // !GTKMM_CHECK_VERSION(3,0,0)
     if( m_iconbox.children().size() == 1 ) return;
 
-    std::string url_to;
     SKELETON::View* icon = get_current_icon();
     Gtk::Box_Helpers::BoxList::iterator it = m_iconbox.children().begin();
     for(; it != m_iconbox.children().end(); ++it ){
@@ -402,6 +461,7 @@ void ImageAdmin::tab_right( const bool updated )
             break;
         }
     }
+#endif // GTKMM_CHECK_VERSION(3,0,0)
 
     if( !url_to.empty() ) switch_img( url_to );
     focus_current_view();
@@ -414,12 +474,20 @@ void ImageAdmin::tab_right( const bool updated )
 //
 void ImageAdmin::tab_head()
 {
+#if GTKMM_CHECK_VERSION(3,0,0)
+    const auto widgets = m_iconbox.get_children();
+    if( widgets.size() == 1 ) return;
+
+    auto view = dynamic_cast< SKELETON::View* >( widgets.front() );
+#else
     if( m_iconbox.children().size() == 1 ) return;
 
-    std::string url_to;
     Gtk::Box_Helpers::BoxList::iterator it = m_iconbox.children().begin();
 
     SKELETON::View* view = dynamic_cast< SKELETON::View* >( it->get_widget() );
+#endif // GTKMM_CHECK_VERSION(3,0,0)
+    std::string url_to;
+
     if( view ) url_to = view->get_url();
 
     if( !url_to.empty() ) switch_img( url_to );
@@ -433,13 +501,21 @@ void ImageAdmin::tab_head()
 //
 void ImageAdmin::tab_tail()
 {
+#if GTKMM_CHECK_VERSION(3,0,0)
+    const auto widgets = m_iconbox.get_children();
+    if( widgets.size() == 1 ) return;
+
+    auto view = dynamic_cast< SKELETON::View* >( widgets.back() );
+#else
     if( m_iconbox.children().size() == 1 ) return;
 
-    std::string url_to;
     Gtk::Box_Helpers::BoxList::iterator it = m_iconbox.children().end();
     it--;
     
     SKELETON::View* view = dynamic_cast< SKELETON::View* >( it->get_widget() );
+#endif // GTKMM_CHECK_VERSION(3,0,0)
+    std::string url_to;
+
     if( view ) url_to = view->get_url();
 
     if( !url_to.empty() ) switch_img( url_to );
@@ -553,6 +629,19 @@ void ImageAdmin::close_view( const std::string& url )
 
         SKELETON::View* view_prev = NULL;
         SKELETON::View* view_next = NULL;        
+#if GTKMM_CHECK_VERSION(3,0,0)
+        const auto widgets = m_iconbox.get_children();
+        for( auto it = widgets.begin(); it != widgets.end(); ++it ) {
+            auto view_tmp = dynamic_cast< SKELETON::View* >( *it );
+            if( view_tmp->get_url() == url ) {
+                if( ++it != widgets.end() ) {
+                    view_next = dynamic_cast< SKELETON::View* >( *it );
+                }
+                break;
+            }
+            view_prev = view_tmp;
+        }
+#else
         Gtk::Box_Helpers::BoxList::iterator it = m_iconbox.children().begin();
         for(; it !=  m_iconbox.children().end(); ++it ){
             SKELETON::View* view_tmp = dynamic_cast< SKELETON::View* >( it->get_widget() );
@@ -562,6 +651,7 @@ void ImageAdmin::close_view( const std::string& url )
             }
             view_prev = view_tmp;
         }
+#endif // GTKMM_CHECK_VERSION(3,0,0)
 
         if( view_next ) url_next = view_next->get_url();
         else if( view_prev ) url_next = view_prev->get_url();
@@ -632,11 +722,20 @@ void ImageAdmin::close_other_views( const std::string& url )
 {
     set_command( "set_imgtab_operating", "", "true" );
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+    m_iconbox.foreach( [this, &url]( Gtk::Widget& w ) {
+        auto view = dynamic_cast< SKELETON::View* >( &w );
+        if( view && view->get_url() != url ) {
+            set_command( "close_view", view->get_url() );
+        }
+    } );
+#else
     Gtk::Box_Helpers::BoxList::iterator it = m_iconbox.children().begin();
     for(; it !=  m_iconbox.children().end(); ++it ){
         SKELETON::View* view = dynamic_cast< SKELETON::View* >( it->get_widget() );
         if( view && view->get_url() != url ) set_command( "close_view", view->get_url() );
     }
+#endif // GTKMM_CHECK_VERSION(3,0,0)
 
     set_command( "set_imgtab_operating", "", "false" );
 }
@@ -649,12 +748,22 @@ void ImageAdmin::close_left_views( const std::string& url )
 {
     set_command( "set_imgtab_operating", "", "true" );
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+    for( auto&& widget : m_iconbox.get_children() ) {
+        auto view = dynamic_cast< SKELETON::View* >( widget );
+        if( view->get_url() == url ) break;
+        if( view ) {
+            set_command( "close_view", view->get_url() );
+        }
+    }
+#else
     Gtk::Box_Helpers::BoxList::iterator it = m_iconbox.children().begin();
     for(; it !=  m_iconbox.children().end(); ++it ){
         SKELETON::View* view = dynamic_cast< SKELETON::View* >( it->get_widget() );
         if( view->get_url() == url ) break;
         if( view ) set_command( "close_view", view->get_url() );
     }
+#endif // GTKMM_CHECK_VERSION(3,0,0)
 
     set_command( "set_imgtab_operating", "", "false" );
 }
@@ -667,6 +776,21 @@ void ImageAdmin::close_right_views( const std::string& url )
 {
     set_command( "set_imgtab_operating", "", "true" );
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+    const auto widgets = m_iconbox.get_children();
+    auto it = widgets.begin();
+    for( ; it != widgets.end(); ++it ) {
+        auto view = dynamic_cast< SKELETON::View* >( *it );
+        if( view->get_url() == url ) break;
+    }
+    ++it;
+    for( ; it != widgets.end(); ++it ) {
+        auto view = dynamic_cast< SKELETON::View* >( *it );
+        if( view ) {
+            set_command( "close_view", view->get_url() );
+        }
+    }
+#else
     Gtk::Box_Helpers::BoxList::iterator it = m_iconbox.children().begin();
     for(; it !=  m_iconbox.children().end(); ++it ){
         SKELETON::View* view = dynamic_cast< SKELETON::View* >( it->get_widget() );
@@ -677,6 +801,7 @@ void ImageAdmin::close_right_views( const std::string& url )
         SKELETON::View* view = dynamic_cast< SKELETON::View* >( it->get_widget() );
         if( view ) set_command( "close_view", view->get_url() );
     }
+#endif // GTKMM_CHECK_VERSION(3,0,0)
 
     set_command( "set_imgtab_operating", "", "false" );
 }
@@ -693,10 +818,20 @@ void ImageAdmin::close_error_views( const std::string mode )
 
     set_command( "set_imgtab_operating", "", "true" );
 
-    Gtk::Box_Helpers::BoxList::iterator it = m_iconbox.children().begin();
-    for(; it !=  m_iconbox.children().end(); ++it ){
+#if GTKMM_CHECK_VERSION(3,0,0)
+    const auto widgets = m_iconbox.get_children();
+    auto it = widgets.begin();
+#else
+    Gtk::Box_Helpers::BoxList& widgets = m_iconbox.children();
+    Gtk::Box_Helpers::BoxList::iterator it = widgets.begin();
+#endif
 
+    for( ; it != widgets.end(); ++it ) {
+#if GTKMM_CHECK_VERSION(3,0,0)
+        auto view = dynamic_cast< SKELETON::View* >( *it );
+#else
         SKELETON::View* view = dynamic_cast< SKELETON::View* >( it->get_widget() );
+#endif
         if( view ){
 
             const std::string url = view->get_url();
@@ -732,10 +867,20 @@ void ImageAdmin::close_noerror_views()
 
     set_command( "set_imgtab_operating", "", "true" );
 
-    Gtk::Box_Helpers::BoxList::iterator it = m_iconbox.children().begin();
-    for(; it !=  m_iconbox.children().end(); ++it ){
+#if GTKMM_CHECK_VERSION(3,0,0)
+    const auto widgets = m_iconbox.get_children();
+    auto it = widgets.begin();
+#else
+    Gtk::Box_Helpers::BoxList& widgets = m_iconbox.children();
+    Gtk::Box_Helpers::BoxList::iterator it = widgets.begin();
+#endif
 
+    for( ; it != widgets.end(); ++it ) {
+#if GTKMM_CHECK_VERSION(3,0,0)
+        auto view = dynamic_cast< SKELETON::View* >( *it );
+#else
         SKELETON::View* view = dynamic_cast< SKELETON::View* >( it->get_widget() );
+#endif
         if( view ){
 
             const std::string url = view->get_url();
@@ -793,11 +938,20 @@ void ImageAdmin::focus_current_view()
 //
 void ImageAdmin::focus_out_all()
 {
+#if GTKMM_CHECK_VERSION(3,0,0)
+    m_iconbox.foreach( []( Gtk::Widget& w ) {
+        auto view = dynamic_cast< SKELETON::View* >( &w );
+        if( view ) {
+            view->focus_out();
+        }
+    } );
+#else
     Gtk::Box_Helpers::BoxList::iterator it = m_iconbox.children().begin();
     for(; it !=  m_iconbox.children().end(); ++it ){
         SKELETON::View* view = dynamic_cast< SKELETON::View* >( it->get_widget() );
         if( view ) view->focus_out();
     }
+#endif // GTKMM_CHECK_VERSION(3,0,0)
 }
 
 
@@ -873,11 +1027,20 @@ void ImageAdmin::switch_img( const std::string& url )
 // 
 SKELETON::View* ImageAdmin::get_icon( const std::string& url, int& pos )
 {
+#if GTKMM_CHECK_VERSION(3,0,0)
+    pos = 0;
+    for( auto&& widget : m_iconbox.get_children() ) {
+        auto view = dynamic_cast< SKELETON::View* >( widget );
+        if( view && view->get_url() == url ) return view;
+        ++pos;
+    }
+#else
     Gtk::Box_Helpers::BoxList::iterator it = m_iconbox.children().begin();
     for( pos = 0; it !=  m_iconbox.children().end(); ++it, ++pos ){
         SKELETON::View* view = dynamic_cast< SKELETON::View* >( it->get_widget() );
         if( view && view->get_url() == url ) return view;
     }
+#endif // GTKMM_CHECK_VERSION(3,0,0)
 
     pos = -1;
     return NULL;
@@ -896,12 +1059,19 @@ SKELETON::View* ImageAdmin::get_icon( const std::string& url)
 //
 SKELETON::View* ImageAdmin::get_nth_icon( const unsigned int n )
 {
+#if GTKMM_CHECK_VERSION(3,0,0)
+    const auto widgets = m_iconbox.get_children();
+    if( n >= widgets.size() ) return nullptr;
+
+    return dynamic_cast< SKELETON::View* >( widgets[ n ] );
+#else
     if( n >= m_iconbox.children().size() ) return NULL;
 
     Gtk::Box_Helpers::BoxList::iterator it = m_iconbox.children().begin();
     for( unsigned int i = 0; i < n; ++i, ++it );
 
     return dynamic_cast< SKELETON::View* >( it->get_widget() );
+#endif // GTKMM_CHECK_VERSION(3,0,0)
 }
 
 
@@ -1187,11 +1357,20 @@ std::list< bool > ImageAdmin::get_locked()
 {
     std::list< bool > locked;
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+    m_iconbox.foreach( [&locked]( Gtk::Widget& w ) {
+        auto view = dynamic_cast< SKELETON::View* >( &w );
+        if( view ) {
+            locked.push_back( view->is_locked() );
+        }
+    } );
+#else
     Gtk::Box_Helpers::BoxList::iterator it = m_iconbox.children().begin();
     for(; it !=  m_iconbox.children().end(); ++it ){
         SKELETON::View* view = dynamic_cast< SKELETON::View* >( it->get_widget() );
         if( view ) locked.push_back( view->is_locked() );
     }
+#endif // GTKMM_CHECK_VERSION(3,0,0)
 
     return locked;
 }

--- a/src/image/imageadmin.cpp
+++ b/src/image/imageadmin.cpp
@@ -49,7 +49,13 @@ ImageAdmin::ImageAdmin( const std::string& url )
     , m_scroll( SCROLL_NO )
 {
     m_scrwin.add( m_iconbox );
+#if GTKMM_CHECK_VERSION(3,16,0)
+    // Gtk::POLICY_NEVERだとスクロール機能自体がなくなり
+    // コンテンツに合わせてGtk::ScrolledWindowのサイズが拡大してしまう
+    m_scrwin.set_policy( Gtk::POLICY_EXTERNAL, Gtk::POLICY_NEVER );
+#else
     m_scrwin.set_policy( Gtk::POLICY_NEVER, Gtk::POLICY_NEVER );
+#endif
     m_scrwin.set_size_request( ICON_SIZE ,  ICON_SIZE + 4);
 
     m_left.set_label( "<" );

--- a/src/image/imageview.cpp
+++ b/src/image/imageview.cpp
@@ -464,8 +464,8 @@ bool ImageViewMain::slot_motion_notify( GdkEventMotion* event )
             || ( ( event->state & GDK_BUTTON3_MASK ) && event_button.button == 3 )
             ){
 
-            Gtk::Adjustment* hadj = m_scrwin->get_hadjustment();
-            Gtk::Adjustment* vadj = m_scrwin->get_vadjustment();
+            auto hadj = m_scrwin->get_hadjustment();
+            auto vadj = m_scrwin->get_vadjustment();
 
             gdouble dx = event->x_root - m_x_motion;
             gdouble dy = event->y_root - m_y_motion;
@@ -500,7 +500,7 @@ void ImageViewMain::scroll_up()
     std::cout << "ImageViewMain::scroll_up\n";
 #endif
 
-    Gtk::Adjustment*  vadjust = m_scrwin->get_vadjustment();
+    auto vadjust = m_scrwin->get_vadjustment();
     if( !vadjust ) return;
     vadjust->set_value( MAX( 0,  vadjust->get_value() - vadjust->get_step_increment() ) );
 }
@@ -515,7 +515,7 @@ void ImageViewMain::scroll_down()
     std::cout << "ImageViewMain::scroll_down\n";
 #endif
 
-    Gtk::Adjustment*  vadjust = m_scrwin->get_vadjustment();
+    auto vadjust = m_scrwin->get_vadjustment();
     if( !vadjust ) return;
     vadjust->set_value(  MIN( vadjust->get_upper() - vadjust->get_page_size(),
                               vadjust->get_value() + vadjust->get_step_increment() ) );
@@ -531,7 +531,7 @@ void ImageViewMain::scroll_left()
     std::cout << "ImageViewMain::scroll_left\n";
 #endif
 
-    Gtk::Adjustment*  hadjust = m_scrwin->get_hadjustment();
+    auto hadjust = m_scrwin->get_hadjustment();
     if( !hadjust ) return;
     hadjust->set_value( MAX( 0,  hadjust->get_value() - hadjust->get_step_increment() ) );
 }
@@ -546,7 +546,7 @@ void ImageViewMain::scroll_right()
     std::cout << "ImageViewMain::scroll_right\n";
 #endif
 
-    Gtk::Adjustment*  hadjust = m_scrwin->get_hadjustment();
+    auto hadjust = m_scrwin->get_hadjustment();
     if( !hadjust ) return;
     hadjust->set_value(  MIN( hadjust->get_upper() - hadjust->get_page_size(),
                               hadjust->get_value() + hadjust->get_step_increment() ) );

--- a/src/image/imageviewicon.cpp
+++ b/src/image/imageviewicon.cpp
@@ -176,9 +176,14 @@ Gtk::Menu* ImageViewIcon::get_popupmenu( const std::string& url )
     if( menu ){
 
         // 一番上のitemのラベルを書き換える
+#if GTKMM_CHECK_VERSION(3,0,0)
+        auto item = dynamic_cast< Gtk::MenuItem* >( menu->get_children().front() );
+        auto label = dynamic_cast< Gtk::Label* >( item->get_child() );
+#else
         Gtk::Menu_Helpers::MenuList::iterator it_item =  menu->items().begin();
 
         Gtk::Label* label = dynamic_cast< Gtk::Label* >( (*it_item).get_child() );
+#endif
         if( label ) label->set_text_with_mnemonic( ITEM_NAME_GO + std::string( " [ タブ数 " )
                                                    + MISC::itostr( IMAGE::get_admin()->get_tab_nums() ) + " ](_M)" );
     }

--- a/src/image/imageviewicon.cpp
+++ b/src/image/imageviewicon.cpp
@@ -22,7 +22,11 @@
 
 
 // 枠を描く
-#define DRAW_FRAME( color ) m_event_frame->modify_bg( Gtk::STATE_NORMAL, color ); 
+#if GTKMM_CHECK_VERSION(3,0,0)
+#define DRAW_FRAME( color ) m_event_frame->override_background_color( Gdk::RGBA( color ), Gtk::STATE_FLAG_NORMAL )
+#else
+#define DRAW_FRAME( color ) m_event_frame->modify_bg( Gtk::STATE_NORMAL, Gdk::Color( color ) )
+#endif
 
 using namespace IMAGE;
 
@@ -42,7 +46,7 @@ ImageViewIcon::ImageViewIcon( const std::string& url )
     pack_start( *m_event_frame );
     m_event_frame->add( get_event() );
     get_event().set_border_width( 1 );
-    DRAW_FRAME( Gdk::Color( "white" ) );
+    DRAW_FRAME( "white" );
 
     setup_common();
 
@@ -103,7 +107,7 @@ void ImageViewIcon::clock_in()
 //
 void ImageViewIcon::focus_view()
 {
-    DRAW_FRAME( Gdk::Color( "red" ) );
+    DRAW_FRAME( "red" );
     get_event().grab_focus();
 }
 
@@ -114,7 +118,7 @@ void ImageViewIcon::focus_view()
 void ImageViewIcon::focus_out()
 {
     SKELETON::View::focus_out();
-    DRAW_FRAME( Gdk::Color( "white" ) );
+    DRAW_FRAME( "white" );
 }
 
 
@@ -157,7 +161,7 @@ void ImageViewIcon::show_view()
 //
 void ImageViewIcon::switch_icon()
 {
-    DRAW_FRAME( Gdk::Color( "red" ) );
+    DRAW_FRAME( "red" );
 }
 
 

--- a/src/image/imageviewicon.cpp
+++ b/src/image/imageviewicon.cpp
@@ -47,7 +47,7 @@ ImageViewIcon::ImageViewIcon( const std::string& url )
     setup_common();
 
     // D&D可能にする
-    std::list< Gtk::TargetEntry > targets;
+    std::vector< Gtk::TargetEntry > targets;
     targets.push_back( Gtk::TargetEntry( DNDTARGET_IMAGETAB, Gtk::TARGET_SAME_APP, 0 ) );
     get_event().drag_dest_set( targets );
 

--- a/src/image/imageviewpopup.cpp
+++ b/src/image/imageviewpopup.cpp
@@ -56,12 +56,22 @@ ImageViewPopup::ImageViewPopup( const std::string& url )
     get_event().set_border_width( margin );
 
     // 枠色
+#if GTKMM_CHECK_VERSION(3,0,0)
+    m_event_frame.override_background_color( Gdk::RGBA( border_color ), Gtk::STATE_FLAG_NORMAL );
+#else
     m_event_frame.modify_bg( Gtk::STATE_NORMAL, Gdk::Color( border_color ) );
+#endif
 
     // 背景色
+#if GTKMM_CHECK_VERSION(3,0,0)
+    const Gdk::RGBA color_bg( bg_color );
+    m_event_margin.override_background_color( color_bg, Gtk::STATE_FLAG_NORMAL );
+    get_event().override_background_color( color_bg, Gtk::STATE_FLAG_NORMAL );
+#else
     const Gdk::Color color_bg( bg_color );
     m_event_margin.modify_bg( Gtk::STATE_NORMAL, color_bg );
     get_event().modify_bg( Gtk::STATE_NORMAL, color_bg );
+#endif
 
     // 全ての領域を表示できないならカーソルの上に表示
     set_popup_upside( true );

--- a/src/image/imageviewpopup.cpp
+++ b/src/image/imageviewpopup.cpp
@@ -137,8 +137,13 @@ void ImageViewPopup::set_label( const std::string& status )
             CORE::CSS_PROPERTY css = CORE::get_css_manager()->get_property( classid );
             if( css.color >= 0 ) text_color = CORE::get_css_manager()->get_color( css.color );
         }
+#if GTKMM_CHECK_VERSION(3,0,0)
+        const Gdk::RGBA color_text( text_color );
+        m_label->override_color( color_text, Gtk::STATE_FLAG_NORMAL );
+#else
         const Gdk::Color color_text( text_color );
         m_label->modify_fg( Gtk::STATE_NORMAL, color_text );
+#endif
 
         m_label->show();
     }

--- a/src/jdlib/miscgtk.cpp
+++ b/src/jdlib/miscgtk.cpp
@@ -41,6 +41,18 @@ std::string MISC::color_to_str( const int* l_rgb )
     return str_value;
 }
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+// Gdk::RGBA -> 16進数表記の文字列
+std::string MISC::color_to_str( const Gdk::RGBA& rgba )
+{
+    int l_rgb[ 3 ];
+    l_rgb[ 0 ] = rgba.get_red_u();
+    l_rgb[ 1 ] = rgba.get_green_u();
+    l_rgb[ 2 ] = rgba.get_blue_u();
+    return color_to_str( l_rgb );
+}
+#endif // GTKMM_CHECK_VERSION(3,0,0)
+
 
 // htmlカラー (#ffffffなど) -> 16進数表記の文字列
 std::string MISC::htmlcolor_to_str( const std::string& _htmlcolor )
@@ -120,7 +132,11 @@ std::set< std::string > MISC::get_font_families()
 std::string MISC::get_entry_font()
 {
     Gtk::Entry entry;
+#if GTKMM_CHECK_VERSION(3,0,0)
+    return entry.get_style_context()->get_font().to_string();
+#else
     return entry.get_style()->get_font().to_string();
+#endif
 }
 
 
@@ -128,7 +144,12 @@ std::string MISC::get_entry_font()
 std::string MISC::get_entry_color_text()
 {
     Gtk::Entry entry;
+#if GTKMM_CHECK_VERSION(3,0,0)
+    auto rgba = entry.get_style_context()->get_color( Gtk::STATE_FLAG_NORMAL );
+    return color_to_str( rgba );
+#else
     return color_to_str( entry.get_style()->get_text( Gtk::STATE_NORMAL ) );
+#endif
 }
 
 
@@ -136,7 +157,20 @@ std::string MISC::get_entry_color_text()
 std::string MISC::get_entry_color_base()
 {
     Gtk::Entry entry;
+#if GTKMM_CHECK_VERSION(3,0,0)
+    // XXX: get_background_color()が期待通りに背景色を返さない環境があった
+    auto context = entry.get_style_context();
+    Gdk::RGBA rgba;
+    if( !context->lookup_color( "theme_base_color", rgba ) ) {
+#ifdef _DEBUG
+        std::cout << "ERROR:MISC::get_entry_color_base() "
+                  << "lookup theme_base_color failed." << std::endl;
+#endif
+    }
+    return color_to_str( rgba );
+#else
     return color_to_str( entry.get_style()->get_base( Gtk::STATE_NORMAL ) );
+#endif
 }
 
 

--- a/src/jdlib/miscgtk.h
+++ b/src/jdlib/miscgtk.h
@@ -5,6 +5,8 @@
 #ifndef _MISCGTK_H
 #define _MISCGTK_H
 
+#include "gtkmmversion.h"
+
 #include <gtkmm.h>
 
 #include <set>
@@ -16,6 +18,11 @@ namespace MISC
 
     // int[3] -> 16進数表記の文字列
     std::string color_to_str( const int* l_rgb );
+
+#if GTKMM_CHECK_VERSION(3,0,0)
+    // Gdk::RGBA -> 16進数表記の文字列
+    std::string color_to_str( const Gdk::RGBA& rgba );
+#endif
 
     // htmlカラー (#ffffffなど) -> 16進数表記の文字列
     std::string htmlcolor_to_str( const std::string& htmlcolor );

--- a/src/jdlib/miscx.cpp
+++ b/src/jdlib/miscx.cpp
@@ -1,6 +1,7 @@
 // ライセンス: GPL2
 
 //#define _DEBUG
+#include "gtkmmversion.h"
 #include "jddebug.h"
 
 #include "miscx.h"
@@ -10,6 +11,10 @@
 #else
 #include <gdk/gdkwin32.h>
 #include <windows.h>
+#endif
+
+#if !defined( GDK_WINDOW_XWINDOW ) && GTKMM_CHECK_VERSION(3,0,0)
+#define GDK_WINDOW_XWINDOW( win ) gdk_x11_window_get_xid( win )
 #endif
 
 //

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -14,10 +14,10 @@
 //#define JDVERSION_SVN
 
 #define MAJORVERSION 2
-#define MINORVERSION 8
-#define MICROVERSION 9
-#define JDDATE    "180424"
-#define JDTAG     ""
+#define MINORVERSION 90
+#define MICROVERSION 1
+#define JDDATE    "180929"
+#define JDTAG     "alpha"
 
 //---------------------------------
 

--- a/src/linkfilterpref.cpp
+++ b/src/linkfilterpref.cpp
@@ -149,7 +149,7 @@ const Gtk::TreeModel::iterator LinkFilterPref::get_selected_row()
 {
     Gtk::TreeModel::iterator row;
 
-    std::list< Gtk::TreeModel::Path > paths = m_treeview.get_selection()->get_selected_rows();
+    std::vector< Gtk::TreeModel::Path > paths = m_treeview.get_selection()->get_selected_rows();
     if( ! paths.size() ) return row;
 
     row = *( m_liststore->get_iter( *paths.begin() ) );

--- a/src/message/messageadmin.cpp
+++ b/src/message/messageadmin.cpp
@@ -400,6 +400,11 @@ const bool MessageAdmin::delete_message( SKELETON::View * view )
             if( ! view->set_command( "save_message" ) ) return delete_message( view );
             result = true;
             break;
+
+        default:
+            // 確認をキャンセルするなら閉じるボタンを見えるようにする
+            m_toolbar->cancel_button_close();
+            break;
     }
 
     return result;

--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -215,10 +215,21 @@ void MessageViewBase::init_font( const std::string& fontname )
     Pango::FontDescription pfd( fontname );
     pfd.set_weight( Pango::WEIGHT_NORMAL );
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+    m_entry_name.override_font( pfd );
+    m_entry_mail.override_font( pfd );
+#else
     m_entry_name.modify_font( pfd );
     m_entry_mail.modify_font( pfd );
+#endif
 
-    if( m_text_message ) m_text_message->modify_font( pfd );
+    if( m_text_message ) {
+#if GTKMM_CHECK_VERSION(3,0,0)
+        m_text_message->override_font( pfd );
+#else
+        m_text_message->modify_font( pfd );
+#endif
+    }
 }
 
 

--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -240,8 +240,15 @@ void MessageViewBase::init_color()
 {
     if( m_text_message ){
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+        m_text_message->override_color( Gdk::RGBA( CONFIG::get_color( COLOR_CHAR_MESSAGE ) ),
+                                        Gtk::STATE_FLAG_NORMAL );
+        m_text_message->override_color( Gdk::RGBA( CONFIG::get_color( COLOR_CHAR_MESSAGE_SELECTION ) ),
+                                        Gtk::STATE_FLAG_SELECTED );
+#else
         m_text_message->modify_text( Gtk::STATE_NORMAL, Gdk::Color( CONFIG::get_color( COLOR_CHAR_MESSAGE ) ) );
         m_text_message->modify_text( Gtk::STATE_SELECTED, Gdk::Color( CONFIG::get_color( COLOR_CHAR_MESSAGE_SELECTION ) ) );
+#endif
         m_text_message->modify_base( Gtk::STATE_NORMAL, Gdk::Color( CONFIG::get_color( COLOR_BACK_MESSAGE ) ) );
         m_text_message->modify_base( Gtk::STATE_SELECTED, Gdk::Color( CONFIG::get_color( COLOR_BACK_MESSAGE_SELECTION ) ) );
     }

--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -245,12 +245,16 @@ void MessageViewBase::init_color()
                                         Gtk::STATE_FLAG_NORMAL );
         m_text_message->override_color( Gdk::RGBA( CONFIG::get_color( COLOR_CHAR_MESSAGE_SELECTION ) ),
                                         Gtk::STATE_FLAG_SELECTED );
+        m_text_message->override_background_color( Gdk::RGBA( CONFIG::get_color( COLOR_BACK_MESSAGE ) ),
+                                                   Gtk::STATE_FLAG_NORMAL );
+        m_text_message->override_background_color( Gdk::RGBA( CONFIG::get_color( COLOR_BACK_MESSAGE_SELECTION ) ),
+                                                   Gtk::STATE_FLAG_SELECTED );
 #else
         m_text_message->modify_text( Gtk::STATE_NORMAL, Gdk::Color( CONFIG::get_color( COLOR_CHAR_MESSAGE ) ) );
         m_text_message->modify_text( Gtk::STATE_SELECTED, Gdk::Color( CONFIG::get_color( COLOR_CHAR_MESSAGE_SELECTION ) ) );
-#endif
         m_text_message->modify_base( Gtk::STATE_NORMAL, Gdk::Color( CONFIG::get_color( COLOR_BACK_MESSAGE ) ) );
         m_text_message->modify_base( Gtk::STATE_SELECTED, Gdk::Color( CONFIG::get_color( COLOR_BACK_MESSAGE_SELECTION ) ) );
+#endif
     }
 }
 

--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -415,8 +415,15 @@ void MessageViewBase::pack_widget()
     m_check_fixname.set_label( "固定" );
     m_check_fixmail.set_label( "固定" );
 
-    m_tooltip.set_tip( m_check_fixname, "チェックすると名前欄を保存して固定にする" );
-    m_tooltip.set_tip( m_check_fixmail, "チェックするとメール欄を保存して固定にする" );
+    constexpr const char* name_tip = "チェックすると名前欄を保存して固定にする";
+    constexpr const char* mail_tip = "チェックするとメール欄を保存して固定にする";
+#if GTKMM_CHECK_VERSION(2,12,0)
+    m_check_fixname.set_tooltip_text( name_tip );
+    m_check_fixmail.set_tooltip_text( mail_tip );
+#else
+    m_tooltip.set_tip( m_check_fixname, name_tip );
+    m_tooltip.set_tip( m_check_fixmail, mail_tip );
+#endif
 
     set_name();
     set_mail();

--- a/src/message/messageviewbase.h
+++ b/src/message/messageviewbase.h
@@ -3,6 +3,8 @@
 #ifndef _MESSAGEVIEWBASE_H
 #define _MESSAGEVIEWBASE_H
 
+#include "gtkmmversion.h"
+
 #include "skeleton/view.h"
 #include "skeleton/imgbutton.h"
 #include "skeleton/compentry.h"
@@ -30,7 +32,9 @@ namespace MESSAGE
     {
         Post* m_post;
 
+#if !GTKMM_CHECK_VERSION(2,12,0)
         Gtk::Tooltips m_tooltip;
+#endif
 
         Gtk::Notebook m_notebook;
         SKELETON::View* m_preview;

--- a/src/message/messageviewbase.h
+++ b/src/message/messageviewbase.h
@@ -10,6 +10,11 @@
 #include "skeleton/compentry.h"
 #include "skeleton/jdtoolbar.h"
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+using GtkNotebookPage = Gtk::Widget;
+#endif
+
+
 namespace JDLIB
 {
     class Iconv;

--- a/src/setupwizard.h
+++ b/src/setupwizard.h
@@ -7,7 +7,13 @@
 #ifndef _SETUPWIZARD_H
 #define _SETUPWIZARD_H
 
+#include "gtkmmversion.h"
+
 #include <gtkmm.h>
+
+#if GTKMM_CHECK_VERSION(3,0,0)
+using GtkNotebookPage = Gtk::Widget;
+#endif
 
 namespace CORE
 {

--- a/src/skeleton/aamenu.cpp
+++ b/src/skeleton/aamenu.cpp
@@ -30,7 +30,11 @@ AAMenu::AAMenu( Gtk::Window& parent )
 
     Pango::FontDescription pfd( CONFIG::get_fontname( FONT_MESSAGE ) );
     pfd.set_weight( Pango::WEIGHT_NORMAL );
+#if GTKMM_CHECK_VERSION(3,0,0)
+    m_textview.override_font( pfd );
+#else
     m_textview.modify_font( pfd );
+#endif
     m_textview.modify_text( Gtk::STATE_NORMAL, Gdk::Color( CONFIG::get_color( COLOR_CHAR_SELECTION ) ) );
     m_textview.modify_base( Gtk::STATE_NORMAL, Gdk::Color( CONFIG::get_color( COLOR_BACK_SELECTION ) ) );
 

--- a/src/skeleton/aamenu.cpp
+++ b/src/skeleton/aamenu.cpp
@@ -234,7 +234,11 @@ void AAMenu::slot_configured_popup( int width, int height )
 {
     int sw = get_screen()->get_width();
     int x, y;
+#if GTKMM_CHECK_VERSION(2,18,0)
+    get_window()->get_root_coords( 0, 0, x, y );
+#else
     get_window()->get_root_origin( x, y );
+#endif
 
 #ifdef _DEBUG
     std::cout << " AAMenu::slot_configured_popup w = " << width

--- a/src/skeleton/aamenu.cpp
+++ b/src/skeleton/aamenu.cpp
@@ -1,6 +1,7 @@
 // AA 選択ポップアップメニュークラス
 
 //#define _DEBUG
+#include "gtkmmversion.h"
 #include "jddebug.h"
 
 #include "aamenu.h"
@@ -13,6 +14,10 @@
 #include "colorid.h"
 #include "aamanager.h"
 #include "cache.h"
+
+#if GTKMM_CHECK_VERSION(3,0,0)
+#include <gdk/gdkkeysyms-compat.h>
+#endif
 
 using namespace SKELETON;
 

--- a/src/skeleton/aamenu.cpp
+++ b/src/skeleton/aamenu.cpp
@@ -52,7 +52,11 @@ AAMenu::~AAMenu()
 
 const int AAMenu::get_size()
 {
+#if GTKMM_CHECK_VERSION(3,0,0)
+    return static_cast< int >( get_children().size() );
+#else
     return items().size();
+#endif
 }
 
 
@@ -127,7 +131,11 @@ void AAMenu::on_map()
 #endif
 
     Gtk::Menu::on_map();
+#if GTKMM_CHECK_VERSION(3,0,0)
+    select_item( *dynamic_cast< Gtk::MenuItem* >( get_children().front() ) );
+#else
     select_item( items()[ 0 ] );
+#endif
 }
 
 
@@ -150,6 +158,19 @@ bool AAMenu::move_down()
     std::cout << "AAMenu::move_down\n";
 #endif
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+    const auto items = get_children();
+    auto it = std::find( items.begin(), items.end(), static_cast< Gtk::Widget* >( m_activeitem ) );
+
+    ++it;
+    if( m_map_items[ dynamic_cast< Gtk::MenuItem* >( *it ) ] == -1 ) {
+        ++it; // セパレータをスキップする
+    }
+    if( it == items.end() ) {
+        it = items.begin(); // 一番下まで行ったら上に戻る
+    }
+    select_item( *dynamic_cast< Gtk::MenuItem* >( *it ) );
+#else
     Gtk::Menu_Helpers::MenuList::iterator it = items().begin();
     for( ; it != items().end() && &(*it) != m_activeitem; ++it );
 
@@ -157,6 +178,7 @@ bool AAMenu::move_down()
     if( m_map_items[ &(*it) ] == -1 ) ++it; // セパレータ
     if( it == items().end() ) it = items().begin(); // 一番下まで行ったら上に戻る
     select_item( *it );
+#endif // GTKMM_CHECK_VERSION(3,0,0)
 
     return true;
 }
@@ -169,6 +191,22 @@ bool AAMenu::move_up()
     std::cout << "AAMenu::move_up\n";
 #endif
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+    const auto items = get_children();
+    auto it = std::find( items.begin(), items.end(), static_cast< Gtk::Widget* >( m_activeitem ) );
+
+    if( it != items.begin() ) {
+        --it;
+        if( m_map_items[ dynamic_cast< Gtk::MenuItem* >( *it ) ] == -1 && it != items.begin() ) {
+            --it; // セパレータをスキップする
+        }
+        select_item( *dynamic_cast< Gtk::MenuItem* >( *it ) );
+    }
+    else {
+        // 一番上に行ったら下に戻る
+        select_item( *dynamic_cast< Gtk::MenuItem* >( items.back() ) );
+    }
+#else
     Gtk::Menu_Helpers::MenuList::iterator it = items().begin();
     for( ; it != items().end() && &(*it) != m_activeitem; ++it );
 
@@ -178,6 +216,7 @@ bool AAMenu::move_up()
         select_item( *it );
     }
     else select_item( items().back() ); // 一番上に行ったら下に戻る
+#endif // GTKMM_CHECK_VERSION(3,0,0)
 
     return true;
 }

--- a/src/skeleton/aamenu.cpp
+++ b/src/skeleton/aamenu.cpp
@@ -34,11 +34,13 @@ AAMenu::AAMenu( Gtk::Window& parent )
     m_textview.override_font( pfd );
     m_textview.override_color( Gdk::RGBA( CONFIG::get_color( COLOR_CHAR_SELECTION ) ),
                                Gtk::STATE_FLAG_NORMAL );
+    m_textview.override_background_color( Gdk::RGBA( CONFIG::get_color( COLOR_BACK_SELECTION ) ),
+                                          Gtk::STATE_FLAG_NORMAL );
 #else
     m_textview.modify_font( pfd );
     m_textview.modify_text( Gtk::STATE_NORMAL, Gdk::Color( CONFIG::get_color( COLOR_CHAR_SELECTION ) ) );
-#endif
     m_textview.modify_base( Gtk::STATE_NORMAL, Gdk::Color( CONFIG::get_color( COLOR_BACK_SELECTION ) ) );
+#endif
 
     m_popup.sig_configured().connect( sigc::mem_fun( *this, &AAMenu::slot_configured_popup ) );
     m_popup.add( m_textview );

--- a/src/skeleton/aamenu.cpp
+++ b/src/skeleton/aamenu.cpp
@@ -32,10 +32,12 @@ AAMenu::AAMenu( Gtk::Window& parent )
     pfd.set_weight( Pango::WEIGHT_NORMAL );
 #if GTKMM_CHECK_VERSION(3,0,0)
     m_textview.override_font( pfd );
+    m_textview.override_color( Gdk::RGBA( CONFIG::get_color( COLOR_CHAR_SELECTION ) ),
+                               Gtk::STATE_FLAG_NORMAL );
 #else
     m_textview.modify_font( pfd );
-#endif
     m_textview.modify_text( Gtk::STATE_NORMAL, Gdk::Color( CONFIG::get_color( COLOR_CHAR_SELECTION ) ) );
+#endif
     m_textview.modify_base( Gtk::STATE_NORMAL, Gdk::Color( CONFIG::get_color( COLOR_BACK_SELECTION ) ) );
 
     m_popup.sig_configured().connect( sigc::mem_fun( *this, &AAMenu::slot_configured_popup ) );

--- a/src/skeleton/aboutdiag.cpp
+++ b/src/skeleton/aboutdiag.cpp
@@ -165,7 +165,11 @@ void AboutDiag::set_version( const Glib::ustring& version )
     const int label_version_font_size = font_discription_version.get_size();
     font_discription_version.set_size( label_version_font_size * 5 / 3 );
     font_discription_version.set_weight( Pango::WEIGHT_BOLD );
+#if GTKMM_CHECK_VERSION(3,0,0)
+    m_label_version.override_font( font_discription_version );
+#else
     m_label_version.modify_font( font_discription_version );
+#endif
 }
 
 Glib::ustring AboutDiag::get_version()

--- a/src/skeleton/aboutdiag.cpp
+++ b/src/skeleton/aboutdiag.cpp
@@ -161,7 +161,11 @@ void AboutDiag::set_version( const Glib::ustring& version )
 {
     m_label_version.set_label( version );
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+    Pango::FontDescription font_discription_version = m_label_version.get_style_context()->get_font();
+#else
     Pango::FontDescription font_discription_version = m_label_version.get_style()->get_font();
+#endif
     const int label_version_font_size = font_discription_version.get_size();
     font_discription_version.set_size( label_version_font_size * 5 / 3 );
     font_discription_version.set_weight( Pango::WEIGHT_BOLD );

--- a/src/skeleton/admin.h
+++ b/src/skeleton/admin.h
@@ -7,6 +7,8 @@
 #ifndef _ADMIN_H
 #define _ADMIN_H
 
+#include "gtkmmversion.h"
+
 #include "dispatchable.h"
 
 #include <gtkmm.h>
@@ -14,6 +16,10 @@
 #include <list>
 
 #include "command_args.h"
+
+#if GTKMM_CHECK_VERSION(3,0,0)
+using GtkNotebookPage = Gtk::Widget;
+#endif
 
 namespace SKELETON
 {

--- a/src/skeleton/compentry.cpp
+++ b/src/skeleton/compentry.cpp
@@ -30,6 +30,11 @@ CompletionEntry::CompletionEntry( const int mode )
     m_entry.signal_activate().connect( sigc::mem_fun( *this, &CompletionEntry::slot_entry_acivate ) );
     m_entry.signal_changed().connect( sigc::mem_fun( *this, &CompletionEntry::slot_entry_changed ) );
     m_entry.signal_focus_out_event().connect( sigc::mem_fun(*this, &CompletionEntry::slot_entry_focus_out ) );
+#if GTKMM_CHECK_VERSION(3,0,0)
+    m_entry.set_max_width_chars( 1 );
+    m_entry.set_width_chars( 1 );
+    m_entry.set_hexpand( true );
+#endif
     pack_start( m_entry );
 
     // ポップアップ

--- a/src/skeleton/compentry.cpp
+++ b/src/skeleton/compentry.cpp
@@ -151,7 +151,18 @@ void CompletionEntry::show_popup( const bool show_all )
 
     m_treeview.unset_cursor();
     m_treeview.scroll_to_point( -1, 0 );
+#if GTKMM_CHECK_VERSION(3,0,0)
+    Gdk::RGBA rgba;
+    if( !get_style_context()->lookup_color( "theme_bg_color", rgba ) ) {
+#ifdef _DEBUG
+        std::cout << "ERROR:CompletionEntry::show_popup() "
+                  << "lookup theme_bg_color faild." << std::endl;
+#endif
+    }
+    m_treeview.get_column_cell_renderer( 0 )->property_cell_background_rgba() = rgba;
+#else
     m_treeview.get_column_cell_renderer( 0 )->property_cell_background_gdk() = get_style()->get_bg( Gtk::STATE_NORMAL );
+#endif // GTKMM_CHECK_VERSION(3,0,0)
 }
 
 

--- a/src/skeleton/compentry.cpp
+++ b/src/skeleton/compentry.cpp
@@ -185,7 +185,10 @@ void CompletionEntry::slot_entry_button_press( GdkEventButton* event )
 #endif
 
     if( m_show_popup ) hide_popup();
-    else if( m_focused ) show_popup( m_entry.get_text().empty() );
+    // 右クリックならコンテキストメニューを優先して補完候補は表示しない
+    else if( m_focused && event->button != 3 ) {
+        show_popup( m_entry.get_text().empty() );
+    }
 
     m_focused = true;
 }

--- a/src/skeleton/compentry.h
+++ b/src/skeleton/compentry.h
@@ -61,7 +61,14 @@ namespace SKELETON
         void set_text( const Glib::ustring& text );
         void grab_focus();
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+        void override_font( Pango::FontDescription& pfd )
+        {
+            m_entry.override_font( pfd );
+        }
+#else
         void modify_font( Pango::FontDescription& pfd ){ m_entry.modify_font( pfd ); }
+#endif
 
       private:
 

--- a/src/skeleton/detaildiag.h
+++ b/src/skeleton/detaildiag.h
@@ -5,7 +5,13 @@
 #ifndef _DETAILDIAG_H
 #define _DETAILDIAG_H
 
+#include "gtkmmversion.h"
+
 #include "prefdiag.h"
+
+#if GTKMM_CHECK_VERSION(3,0,0)
+using GtkNotebookPage = Gtk::Widget;
+#endif
 
 namespace SKELETON
 {

--- a/src/skeleton/dragnote.cpp
+++ b/src/skeleton/dragnote.cpp
@@ -111,6 +111,7 @@ void DragableNoteBook::focus_out()
 // Auroraなどテーマによっては m_notebook_toolbar が m_notebook_view に上書きされて
 // 消えてしまうのでもう一度 m_notebook_toolbar を描画する
 //
+#if !GTKMM_CHECK_VERSION(3,0,0)
 bool DragableNoteBook::on_expose_event( GdkEventExpose* event )
 {
     const bool ret =  Gtk::VBox::on_expose_event( event );
@@ -159,12 +160,14 @@ bool DragableNoteBook::on_expose_event( GdkEventExpose* event )
     }
     return ret;
 }
+#endif // !GTKMM_CHECK_VERSION(3,0,0)
 
 
 //
 // DragableNoteBook を構成している各Notebookの高さ
 // 及びタブの高さと位置を取得 ( 枠の描画用 )
 //
+#if !GTKMM_CHECK_VERSION(3,0,0)
 const Alloc_NoteBook DragableNoteBook::get_alloc_notebook()
 {
     Alloc_NoteBook alloc;
@@ -201,6 +204,7 @@ const Alloc_NoteBook DragableNoteBook::get_alloc_notebook()
 
     return alloc;
 }
+#endif // !GTKMM_CHECK_VERSION(3,0,0)
 
 
 //
@@ -208,6 +212,7 @@ const Alloc_NoteBook DragableNoteBook::get_alloc_notebook()
 //
 // gtknotebook.c( Revision 19593, Sat Feb 16 04:09:15 2008 UTC ) からのハック。環境やバージョンによっては問題が出るかもしれないので注意
 //
+#if !GTKMM_CHECK_VERSION(3,0,0)
 void DragableNoteBook::draw_box( Gtk::Widget* widget, GdkEventExpose* event )
 {
     const Glib::RefPtr<Gdk::Window> win = widget->get_window();
@@ -260,6 +265,7 @@ void DragableNoteBook::draw_box( Gtk::Widget* widget, GdkEventExpose* event )
         }
     }
 }
+#endif // !GTKMM_CHECK_VERSION(3,0,0)
 
 
 void DragableNoteBook::set_show_tabs( bool show_tabs )

--- a/src/skeleton/dragnote.cpp
+++ b/src/skeleton/dragnote.cpp
@@ -46,7 +46,12 @@ DragableNoteBook::DragableNoteBook()
 
     m_hbox_tab.pack_start( m_notebook_tab );
     m_hbox_tab.pack_start( m_bt_tabswitch, Gtk::PACK_SHRINK );
-    m_tooltip_tabswitch.set_tip( m_bt_tabswitch, "タブの一覧表示" );
+    constexpr const char* bt_tabswitch_tip = "タブの一覧表示";
+#if GTKMM_CHECK_VERSION(2,12,0)
+    m_bt_tabswitch.set_tooltip_text( bt_tabswitch_tip );
+#else
+    m_tooltip_tabswitch.set_tip( m_bt_tabswitch, bt_tabswitch_tip );
+#endif
 
     pack_start( m_hbox_tab, Gtk::PACK_SHRINK );
     pack_start( m_notebook_toolbar, Gtk::PACK_SHRINK );

--- a/src/skeleton/dragnote.cpp
+++ b/src/skeleton/dragnote.cpp
@@ -579,7 +579,12 @@ SKELETON::TabLabel* DragableNoteBook::create_tablabel( const std::string& url )
 {
     SKELETON::TabLabel *tablabel = new SKELETON::TabLabel( url );
 
-#if !GTKMM_CHECK_VERSION(2,10,0)
+#if GTKMM_CHECK_VERSION(2,10,0)
+    tablabel->sig_tab_button_press_event().connect(
+        sigc::mem_fun( m_notebook_tab, &TabNotebook::slot_tab_button_event ) );
+    tablabel->sig_tab_button_release_event().connect(
+        sigc::mem_fun( m_notebook_tab, &TabNotebook::slot_tab_button_event ) );
+#else
     // ドラッグ設定
     GdkEventButton event;
     m_control.get_eventbutton( CONTROL::DragStartButton, event );
@@ -591,7 +596,7 @@ SKELETON::TabLabel* DragableNoteBook::create_tablabel( const std::string& url )
     tablabel->sig_tab_drag_begin().connect( sigc::mem_fun(*this, &DragableNoteBook::slot_drag_begin ) );
     tablabel->sig_tab_drag_data_get().connect( sigc::mem_fun(*this, &DragableNoteBook::slot_drag_data_get ) );
     tablabel->sig_tab_drag_end().connect( sigc::mem_fun(*this, &DragableNoteBook::slot_drag_end ) );
-#endif // !GTKMM_CHECK_VERSION(2,10,0)
+#endif // GTKMM_CHECK_VERSION(2,10,0)
     
     return tablabel;
 }

--- a/src/skeleton/dragnote.cpp
+++ b/src/skeleton/dragnote.cpp
@@ -12,6 +12,7 @@
 #include "icons/iconmanager.h"
 
 #include "control/controlid.h"
+#include "jdlib/timeout.h"
 
 #include "dndmanager.h"
 #include "session.h"
@@ -638,6 +639,15 @@ void DragableNoteBook::slot_switch_page_tab( GtkNotebookPage* bookpage, guint pa
     m_notebook_toolbar.queue_draw();
 
     m_sig_switch_page.emit( bookpage, page );
+
+#if GTKMM_CHECK_VERSION(3,0,0)
+    if( get_timeout_drawn() ) {
+        // XXX: ArticleAdminのタブやツールバーを描画するためタイマーを設定する
+        // 特定の板のスレにタブを切り替えるときにタブやツールバーの描画が
+        // 更新されない不具合を回避する
+        start_draw_timer( this, TIMEOUT_DRAWN_SWITCH_PAGE_TAB );
+    }
+#endif
 }
 
 
@@ -941,3 +951,18 @@ void DragableNoteBook::slot_drag_end()
     CORE::DND_End();
 }
 #endif // !GTKMM_CHECK_VERSION(2,10,0)
+
+
+#if GTKMM_CHECK_VERSION(3,0,0)
+void DragableNoteBook::start_draw_timer( Gtk::Widget* widget, unsigned int timeout )
+{
+    assert( widget != nullptr );
+    // 描画処理が済むとタイマーは解除される
+    JDLIB::Timeout::connect(
+        [widget]() {
+            widget->queue_draw();
+            return false;
+        },
+        timeout );
+}
+#endif // GTKMM_CHECK_VERSION(3,0,0)

--- a/src/skeleton/dragnote.h
+++ b/src/skeleton/dragnote.h
@@ -77,7 +77,9 @@ namespace SKELETON
 
         Gtk::HBox m_hbox_tab;
         TabSwitchButton m_bt_tabswitch; // タブの切り替えボタン
+#if !GTKMM_CHECK_VERSION(2,12,0)
         Gtk::Tooltips m_tooltip_tabswitch;
+#endif
 
         bool m_show_tabs;
         bool m_show_toolbar;

--- a/src/skeleton/dragnote.h
+++ b/src/skeleton/dragnote.h
@@ -11,6 +11,8 @@
 #ifndef _DRAGNOTE_H
 #define _DRAGNOTE_H
 
+#include "gtkmmversion.h"
+
 #include "tabnote.h"
 #include "toolbarnote.h"
 #include "viewnote.h"

--- a/src/skeleton/dragnote.h
+++ b/src/skeleton/dragnote.h
@@ -96,11 +96,15 @@ namespace SKELETON
         // 入力コントローラ
         CONTROL::Control m_control;
 
+#if !GTKMM_CHECK_VERSION(2,10,0)
         Tooltip m_tooltip;
+#endif
 
         bool m_dragable;
 
+#if !GTKMM_CHECK_VERSION(2,10,0)
         SKELETON::IconPopup* m_down_arrow;
+#endif
 
         Alloc_NoteBook m_alloc_old;
 
@@ -189,14 +193,22 @@ namespace SKELETON
         bool slot_button_press_event( GdkEventButton* event );
         bool slot_button_release_event( GdkEventButton* event );
 
+#if !GTKMM_CHECK_VERSION(2,10,0)
         // notebook_tab の上でホイールを回した
         bool slot_scroll_event( GdkEventScroll* event );
+#endif
 
       protected:
 
         // コントローラ
         CONTROL::Control& get_control(){ return m_control; }
 
+#if GTKMM_CHECK_VERSION(2,10,0)
+        void slot_page_reordered( Gtk::Widget*, guint page_num );
+
+        void slot_drag_data_get( const Glib::RefPtr< Gdk::DragContext >& context,
+                                 Gtk::SelectionData& selection_data, guint info, guint time );
+#else
         // タブからくるシグナルにコネクトする
         void slot_motion_event();
         void slot_leave_event();
@@ -205,6 +217,7 @@ namespace SKELETON
         void slot_drag_motion( const int page, const int tab_x, const int tab_y, const int tab_width );
         void slot_drag_data_get( Gtk::SelectionData& selection_data );
         void slot_drag_end();
+#endif // GTKMM_CHECK_VERSION(2,10,0)
     };
 }
 

--- a/src/skeleton/dragnote.h
+++ b/src/skeleton/dragnote.h
@@ -26,6 +26,16 @@
 
 namespace SKELETON
 {
+#if GTKMM_CHECK_VERSION(3,0,0)
+    // 描画タイマーのタイムアウト値 (単位はミリ秒)
+    // XXX: マシンごとに適切なタイムアウト値があるはず
+    enum
+    {
+        TIMEOUT_DRAWN_SWITCH_PAGE_TAB = 200U,
+        TIMEOUT_DRAWN_SET_TAB_FULLTEXT = 400U,
+    };
+#endif
+
     class View;
     class ToolBar;
     class TabLabel;
@@ -102,6 +112,10 @@ namespace SKELETON
 
         bool m_dragable;
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+        bool m_timeout_drawn = false;
+#endif
+
 #if !GTKMM_CHECK_VERSION(2,10,0)
         SKELETON::IconPopup* m_down_arrow;
 #endif
@@ -173,6 +187,14 @@ namespace SKELETON
 
         // タブ切り替えボタン
         Gtk::Button& get_tabswitch_button(){ return m_bt_tabswitch.get_button(); }
+
+#if GTKMM_CHECK_VERSION(3,0,0)
+        const bool get_timeout_drawn() const { return m_timeout_drawn; }
+        void set_timeout_drawn( bool timeout_drawn ) { m_timeout_drawn = timeout_drawn; }
+
+        // 描画タイマーをスタートする (タイムアウト値の単位はミリ秒)
+        void start_draw_timer( Gtk::Widget* widget, unsigned int timeout );
+#endif
 
       private:
 

--- a/src/skeleton/dragnote.h
+++ b/src/skeleton/dragnote.h
@@ -125,8 +125,10 @@ namespace SKELETON
         void clock_in();
         void focus_out();
 
+#if !GTKMM_CHECK_VERSION(3,0,0)
         // 枠描画
         void draw_box( Gtk::Widget* widget, GdkEventExpose* event );
+#endif
 
         const bool get_show_tabs() const{ return m_show_tabs; }
         void set_show_tabs( bool show_tabs );
@@ -174,11 +176,15 @@ namespace SKELETON
 
       private:
 
+#if !GTKMM_CHECK_VERSION(3,0,0)
         virtual bool on_expose_event( GdkEventExpose* event );
+#endif
 
+#if !GTKMM_CHECK_VERSION(3,0,0)
         // DragableNoteBook を構成している各Notebookの高さ
         // 及びタブの高さと位置を取得 ( 枠の描画用 )
         const Alloc_NoteBook get_alloc_notebook();
+#endif
 
         // ツールバー取得
         SKELETON::ToolBar* get_toolbar( int page );

--- a/src/skeleton/dragtreeview.cpp
+++ b/src/skeleton/dragtreeview.cpp
@@ -2,6 +2,7 @@
 
 //#define _DEBUG
 #include "jddebug.h"
+#include "gtkmmversion.h"
 
 #include "dragtreeview.h"
 #include "view.h"
@@ -136,7 +137,11 @@ void DragTreeView::init_font( const std::string& fontname )
 {
     Pango::FontDescription pfd( fontname );
     pfd.set_weight( Pango::WEIGHT_NORMAL );
+#if GTKMM_CHECK_VERSION(3,0,0)
+    override_font( pfd );
+#else
     modify_font( pfd );
+#endif
 
     m_tooltip.modify_font_label( fontname );
 }

--- a/src/skeleton/dragtreeview.cpp
+++ b/src/skeleton/dragtreeview.cpp
@@ -127,7 +127,11 @@ void DragTreeView::init_color( const int colorid_text, const int colorid_bg, con
 
     // 背景色
     m_color_bg.set( CONFIG::get_color( colorid_bg ) );
+#if GTKMM_CHECK_VERSION(3,0,0)
+    override_background_color( m_color_bg, get_state_flags() );
+#else
     modify_base( get_state(), m_color_bg );
+#endif
 
     m_use_bg_even = ! ( CONFIG::get_color( colorid_bg ) == CONFIG::get_color( colorid_bg_even ) );
     m_color_bg_even.set( CONFIG::get_color( colorid_bg_even ) );

--- a/src/skeleton/dragtreeview.cpp
+++ b/src/skeleton/dragtreeview.cpp
@@ -58,7 +58,7 @@ DragTreeView::DragTreeView( const std::string& url, const std::string& dndtarget
     get_selection()->signal_changed().connect( sigc::mem_fun( *this, &DragTreeView::slot_selection_changed ) );
 
     // D&D 設定
-    std::list< Gtk::TargetEntry > targets;
+    std::vector< Gtk::TargetEntry > targets;
     targets.push_back( Gtk::TargetEntry( get_dndtarget(), Gtk::TARGET_SAME_APP, 0 ) );
 
     // ドラッグ開始ボタン設定
@@ -89,7 +89,7 @@ DragTreeView::~DragTreeView()
 //
 void DragTreeView::set_enable_drop_uri_list()
 {
-    std::list< Gtk::TargetEntry > targets_drop;
+    std::vector< Gtk::TargetEntry > targets_drop;
     targets_drop.push_back( Gtk::TargetEntry( "text/uri-list" ) );
 
     // ドロップされると on_drag_data_received() が呼び出される

--- a/src/skeleton/dragtreeview.cpp
+++ b/src/skeleton/dragtreeview.cpp
@@ -499,7 +499,7 @@ bool DragTreeView::on_scroll_event( GdkEventScroll* event )
 //
 void DragTreeView::wheelscroll( GdkEventScroll* event )
 {
-    Gtk::Adjustment *adj = get_vadjustment();
+    auto adj = get_vadjustment();
     double val = adj->get_value();
 
     int scr_inc = get_row_height() * CONFIG::get_tree_scroll_size();

--- a/src/skeleton/dragtreeview.cpp
+++ b/src/skeleton/dragtreeview.cpp
@@ -119,7 +119,11 @@ void DragTreeView::init_color( const int colorid_text, const int colorid_bg, con
 
     // 文字色
     m_color_text.set( CONFIG::get_color( colorid_text ) );
+#if GTKMM_CHECK_VERSION(3,0,0)
+    override_color( m_color_text, get_state_flags() );
+#else
     modify_text( get_state(), m_color_text );
+#endif
 
     // 背景色
     m_color_bg.set( CONFIG::get_color( colorid_bg ) );

--- a/src/skeleton/dragtreeview.h
+++ b/src/skeleton/dragtreeview.h
@@ -44,10 +44,11 @@ namespace SKELETON
         bool m_use_bg_even;
 #if GTKMM_CHECK_VERSION(3,0,0)
         Gdk::RGBA m_color_text;
+        Gdk::RGBA m_color_bg;
 #else
         Gdk::Color m_color_text;
-#endif
         Gdk::Color m_color_bg;
+#endif
         Gdk::Color m_color_bg_even;
 
         // ポップアップウィンドウ用

--- a/src/skeleton/dragtreeview.h
+++ b/src/skeleton/dragtreeview.h
@@ -42,7 +42,11 @@ namespace SKELETON
 
         // 色
         bool m_use_bg_even;
+#if GTKMM_CHECK_VERSION(3,0,0)
+        Gdk::RGBA m_color_text;
+#else
         Gdk::Color m_color_text;
+#endif
         Gdk::Color m_color_bg;
         Gdk::Color m_color_bg_even;
 

--- a/src/skeleton/edittreeview.cpp
+++ b/src/skeleton/edittreeview.cpp
@@ -227,7 +227,12 @@ void EditTreeView::set_editable_view( const bool editable )
         // D&D のドロップを可能にする
         std::vector< Gtk::TargetEntry > targets;
         targets.push_back( Gtk::TargetEntry( get_dndtarget(), Gtk::TARGET_SAME_APP, 0 ) );
+#if GTKMM_CHECK_VERSION(2,10,0)
+        targets.emplace_back( "GTK_NOTEBOOK_TAB", Gtk::TARGET_SAME_APP, 0 );
+        drag_dest_set( targets, Gtk::DEST_DEFAULT_ALL, Gdk::ACTION_MOVE | Gdk::ACTION_COPY );
+#else
         drag_dest_set( targets );
+#endif
     }
 }
 
@@ -745,7 +750,12 @@ void EditTreeView::on_drag_data_received( const Glib::RefPtr<Gdk::DragContext>& 
     m_dropped_from_other = false;
 
     // 挿入先のrowを保存
-    if( m_editable && selection_data.get_target() == get_dndtarget() ){
+    const std::string target = selection_data.get_target();
+    if( m_editable && ( target == get_dndtarget()
+#if GTKMM_CHECK_VERSION(2,10,0)
+                        || target == "GTK_NOTEBOOK_TAB"
+#endif
+                        ) ) {
 
         CORE::DATA_INFO_LIST list_info = CORE::SBUF_list_info();
         if( ! list_info.size() ) return;

--- a/src/skeleton/edittreeview.cpp
+++ b/src/skeleton/edittreeview.cpp
@@ -248,7 +248,7 @@ void EditTreeView::clock_in()
             m_dnd_counter = 0;
 
             Gtk::TreePath path = get_path_under_mouse();
-            Gtk::Adjustment* adjust = get_vadjustment();
+            auto adjust = get_vadjustment();
 
             if( get_row( path ) && adjust ){
 

--- a/src/skeleton/edittreeview.cpp
+++ b/src/skeleton/edittreeview.cpp
@@ -225,7 +225,7 @@ void EditTreeView::set_editable_view( const bool editable )
     if( m_editable ){
 
         // D&D のドロップを可能にする
-        std::list< Gtk::TargetEntry > targets;
+        std::vector< Gtk::TargetEntry > targets;
         targets.push_back( Gtk::TargetEntry( get_dndtarget(), Gtk::TARGET_SAME_APP, 0 ) );
         drag_dest_set( targets );
     }

--- a/src/skeleton/edittreeview.cpp
+++ b/src/skeleton/edittreeview.cpp
@@ -1369,7 +1369,7 @@ void EditTreeView::replace_infopath( CORE::DATA_INFO_LIST& list_info,
 
         if( children.empty() ) path = Gtk::TreePath( "0" );
         else{
-            path = get_model()->get_path( *( children.rbegin() ) );
+            path = get_model()->get_path( *( std::prev( children.end() ) ) );
             path.next();
         }
     }

--- a/src/skeleton/editview.cpp
+++ b/src/skeleton/editview.cpp
@@ -348,6 +348,15 @@ bool EditTextView::on_key_press_event( GdkEventKey* event )
         case CONTROL::UndoEdit:
         case CONTROL::InputAA:
         {
+#if GTKMM_CHECK_VERSION(2,22,0)
+            if( im_context_filter_keypress( event ) ) {
+#ifdef _DEBUG
+                std::cout << "gtk_im_context_filter_keypress\n";
+#endif
+                reset_im_context();
+                return true;
+            }
+#else
             GtkTextView *textview = gobj();
             if( gtk_im_context_filter_keypress( textview->im_context, event ) )
             {
@@ -357,6 +366,7 @@ bool EditTextView::on_key_press_event( GdkEventKey* event )
                 textview->need_im_reset = TRUE;
                 return true;
             }
+#endif // GTKMM_CHECK_VERSION(2,22,0)
         }
     }
 

--- a/src/skeleton/editview.cpp
+++ b/src/skeleton/editview.cpp
@@ -1,6 +1,7 @@
 // ライセンス: GPL2
 
 //#define _DEBUG
+#include "gtkmmversion.h"
 #include "jddebug.h"
 
 #include "editview.h"
@@ -17,6 +18,10 @@
 #include "config/globalconf.h"
 
 #include "gtk/gtktextview.h"
+
+#if GTKMM_CHECK_VERSION(3,0,0)
+#include <gdk/gdkkeysyms-compat.h>
+#endif
 
 using namespace SKELETON;
 

--- a/src/skeleton/editview.h
+++ b/src/skeleton/editview.h
@@ -152,7 +152,14 @@ namespace SKELETON
 
         void set_wrap_mode( Gtk::WrapMode wrap_mode ){ m_textview.set_wrap_mode( wrap_mode ); }
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+        void override_color( const Gdk::RGBA& color, Gtk::StateFlags state )
+        {
+            m_textview.override_color( color, state );
+        }
+#else
         void modify_text( Gtk::StateType state, const Gdk::Color& color ){ m_textview.modify_text( state, color ); }
+#endif
         void modify_base( Gtk::StateType state, const Gdk::Color& color ){ m_textview.modify_base( state, color ); }
 
         void insert_str( const std::string& str, bool use_br ){ m_textview.insert_str( str, use_br ); }

--- a/src/skeleton/editview.h
+++ b/src/skeleton/editview.h
@@ -3,6 +3,8 @@
 #ifndef _EDITVIEW_H
 #define _EDITVIEW_H
 
+#include "gtkmmversion.h"
+
 #include <gtkmm.h>
 
 #include "control/control.h"
@@ -158,7 +160,14 @@ namespace SKELETON
         void set_editable( bool editable ){ m_textview.set_editable( editable ); }
         void set_accepts_tab( bool accept ){ m_textview.set_accepts_tab( accept ); }
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+        void override_font( const Pango::FontDescription& font_desc )
+        {
+            m_textview.override_font( font_desc );
+        }
+#else
         void modify_font( const Pango::FontDescription& font_desc ){ m_textview.modify_font( font_desc ); }
+#endif
 
         void focus_view(){ m_textview.grab_focus(); }
 

--- a/src/skeleton/editview.h
+++ b/src/skeleton/editview.h
@@ -157,10 +157,14 @@ namespace SKELETON
         {
             m_textview.override_color( color, state );
         }
+        void override_background_color( const Gdk::RGBA& color, Gtk::StateFlags state )
+        {
+            m_textview.override_background_color( color, state );
+        }
 #else
         void modify_text( Gtk::StateType state, const Gdk::Color& color ){ m_textview.modify_text( state, color ); }
-#endif
         void modify_base( Gtk::StateType state, const Gdk::Color& color ){ m_textview.modify_base( state, color ); }
+#endif
 
         void insert_str( const std::string& str, bool use_br ){ m_textview.insert_str( str, use_br ); }
 

--- a/src/skeleton/entry.cpp
+++ b/src/skeleton/entry.cpp
@@ -1,12 +1,16 @@
 // ライセンス: GPL2
 
 //#define _DEBUG
+#include "gtkmmversion.h"
 #include "jddebug.h"
 
 #include "entry.h"
 
 #include "control/controlid.h"
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+#include <gdk/gdkkeysyms-compat.h>
+#endif
 #include <gtk/gtkentry.h>
 
 using namespace SKELETON;

--- a/src/skeleton/entry.cpp
+++ b/src/skeleton/entry.cpp
@@ -44,6 +44,15 @@ bool JDEntry::on_key_press_event( GdkEventKey* event )
     // gtkentry.cpp からのハック。環境やバージョンによっては問題が出るかもしれないので注意
     if( up || down || esc ){
 
+#if GTKMM_CHECK_VERSION(2,22,0)
+        if( im_context_filter_keypress( event ) ) {
+#ifdef _DEBUG
+            std::cout << "gtk_im_context_filter_keypress\n";
+#endif
+            reset_im_context();
+            return TRUE;
+        }
+#else
         GtkEntry *entry = gobj();
         if( gtk_im_context_filter_keypress( entry->im_context, event ) )
         {
@@ -54,6 +63,7 @@ bool JDEntry::on_key_press_event( GdkEventKey* event )
 
             return TRUE;
         }
+#endif // GTKMM_CHECK_VERSION(2,22,0)
         else if( up || down ){
 
             if( up ) m_sig_operate.emit( CONTROL::Up );

--- a/src/skeleton/iconpopup.h
+++ b/src/skeleton/iconpopup.h
@@ -22,13 +22,10 @@ namespace SKELETON
             m_img.set( m_pixbuf );
 
 #if GTKMM_CHECK_VERSION(3,0,0)
-            cairo_t* cr = gdk_cairo_create( m_img.get_window()->gobj() );
-            cairo_region_t* rg = gdk_cairo_region_create_from_surface( cairo_get_target( cr ) );
-
-            gtk_widget_shape_combine_region( GTK_WIDGET( gobj() ), rg );
-
-            cairo_region_destroy( rg );
-            cairo_destroy( cr );
+            set_decorated( false );
+            set_app_paintable( true );
+            auto visual = get_screen()->get_rgba_visual();
+            gtk_widget_set_visual( GTK_WIDGET( gobj() ), visual->gobj() );
 #else
             Glib::RefPtr< Gdk::Pixmap > pixmap;
             Glib::RefPtr< Gdk::Bitmap > bitmap;

--- a/src/skeleton/iconpopup.h
+++ b/src/skeleton/iconpopup.h
@@ -18,14 +18,24 @@ namespace SKELETON
 
       IconPopup( const int icon_id ) : Gtk::Window( Gtk::WINDOW_POPUP ){
 
-            Glib::RefPtr< Gdk::Pixmap > pixmap;
-            Glib::RefPtr< Gdk::Bitmap > bitmap;
-
             m_pixbuf = ICON::get_icon( icon_id );
             m_img.set( m_pixbuf );
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+            cairo_t* cr = gdk_cairo_create( m_img.get_window()->gobj() );
+            cairo_region_t* rg = gdk_cairo_region_create_from_surface( cairo_get_target( cr ) );
+
+            gtk_widget_shape_combine_region( GTK_WIDGET( gobj() ), rg );
+
+            cairo_region_destroy( rg );
+            cairo_destroy( cr );
+#else
+            Glib::RefPtr< Gdk::Pixmap > pixmap;
+            Glib::RefPtr< Gdk::Bitmap > bitmap;
+
             m_pixbuf->render_pixmap_and_mask( pixmap, bitmap, 255 );
             shape_combine_mask( bitmap, 0, 0 );
+#endif // GTKMM_CHECK_VERSION(3,0,0)
 
             add( m_img );
             show_all_children();

--- a/src/skeleton/jdtoolbar.cpp
+++ b/src/skeleton/jdtoolbar.cpp
@@ -11,6 +11,8 @@
 
 #include <gtk/gtk.h>
 
+#if !GTKMM_CHECK_VERSION(3,0,0)
+
 ///////////////////////////////////////////
 //
 // gtk+-2.12.9/gtk/gtktoolbar.c より引用
@@ -205,3 +207,5 @@ bool JDToolbar::on_expose_event( GdkEventExpose* event )
 
     return FALSE;
 }
+
+#endif // !GTKMM_CHECK_VERSION(3,0,0)

--- a/src/skeleton/jdtoolbar.h
+++ b/src/skeleton/jdtoolbar.h
@@ -17,8 +17,11 @@ namespace SKELETON
     public:
         JDToolbar(){}
 
+        // GTK+3ではデフォルトの描画処理に任せる
+#if !GTKMM_CHECK_VERSION(3,0,0)
     protected:
         virtual bool on_expose_event( GdkEventExpose* event );
+#endif
     };
 }
 

--- a/src/skeleton/menubutton.cpp
+++ b/src/skeleton/menubutton.cpp
@@ -89,8 +89,10 @@ MenuButton::~MenuButton()
 
 void MenuButton::set_tooltip_arrow( const std::string& tooltip )
 {
-#if GTKMM_CHECK_VERSION(2,13,0)
-    if( m_arrow ) m_tooltip_arrow.set_tip( *m_arrow, tooltip );
+#if GTKMM_CHECK_VERSION(2,12,0)
+    if( m_arrow ) {
+        m_arrow->set_tooltip_text( tooltip );
+    }
 #else
     // gtkmm-2.12.0より前のバージョンはボタンの中のWidgetにツールチップを設定できない
     m_tooltip_arrow.set_tip( *this, tooltip );

--- a/src/skeleton/menubutton.h
+++ b/src/skeleton/menubutton.h
@@ -28,7 +28,9 @@ namespace SKELETON
         std::vector< Gtk::MenuItem* > m_menuitems;
         Gtk::Widget* m_label;
 
+#if !GTKMM_CHECK_VERSION(2,12,0)
         Gtk::Tooltips m_tooltip_arrow;
+#endif
         Gtk::Arrow* m_arrow;
 
         bool m_on_arrow;

--- a/src/skeleton/msgdiag.cpp
+++ b/src/skeleton/msgdiag.cpp
@@ -10,8 +10,10 @@
 #include "dispatchmanager.h"
 #include "global.h"
 
+#if !GTKMM_CHECK_VERSION(2,22,0)
 #include <gtk/gtkmessagedialog.h>
 #include <gtk/gtklabel.h>
+#endif
 
 using namespace SKELETON;
 
@@ -37,12 +39,20 @@ MsgDiag::MsgDiag( Gtk::Window* parent,
     if( parent ) set_transient_for( *parent );
     else set_transient_for( *CORE::get_mainwindow() );
 
+#if GTKMM_CHECK_VERSION(2,22,0)
+    std::vector< Gtk::Widget* > area = get_message_area()->get_children();
+    Gtk::Label* primary_label = dynamic_cast< Gtk::Label* >( area.front() );
+    if( primary_label ) {
+        primary_label->set_can_focus( false );
+    }
+#else
     // tab でラベルにフォーカスが移らないようにする ( messagedialog.ccg をハックした )
     Gtk::Widget* wdt = Glib::wrap( gobj()->label );
     if( wdt ){
         Gtk::Label* label = dynamic_cast< Gtk::Label* >( wdt );
         if( label ) label->property_can_focus() = false;
     }
+#endif // GTKMM_CHECK_VERSION(2,22,0)
 }
 
 

--- a/src/skeleton/popupwin.cpp
+++ b/src/skeleton/popupwin.cpp
@@ -52,8 +52,12 @@ void PopupWin::slot_resize_popup()
     
     // マウス座標
     int x_mouse, y_mouse;
+#if GTKMM_CHECK_VERSION(3,0,0)
+    Gdk::Display::get_default()->get_device_manager()->get_client_pointer()->get_position( x_mouse, y_mouse );
+#else
     Gdk::ModifierType mod;
     Gdk::Display::get_default()->get_pointer( x_mouse, y_mouse,  mod );
+#endif
 
     // クライアントのサイズを取得
     const int width_client = m_view->width_client();

--- a/src/skeleton/popupwinbase.h
+++ b/src/skeleton/popupwinbase.h
@@ -56,6 +56,19 @@ namespace SKELETON
 #endif
         }
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+        virtual bool on_draw( const Cairo::RefPtr< Cairo::Context >& cr ) override
+        {
+            const bool ret = Gtk::Window::on_draw( cr );
+            if( m_draw_frame ) {
+                Gdk::Cairo::set_source_rgba( cr, Gdk::RGBA( "black" ) );
+                cr->set_line_width( 1.0 );
+                cr->rectangle( 0.0, 0.0, get_width(), get_height() );
+                cr->stroke();
+            }
+            return ret;
+        }
+#else
         virtual bool on_expose_event( GdkEventExpose* event )
         {
             bool ret = Gtk::Window::on_expose_event( event );
@@ -79,6 +92,7 @@ namespace SKELETON
 
             return ret;
         }
+#endif // GTKMM_CHECK_VERSION(3,0,0)
 
         virtual bool on_configure_event( GdkEventConfigure* event )
         {

--- a/src/skeleton/prefdiag.cpp
+++ b/src/skeleton/prefdiag.cpp
@@ -106,6 +106,18 @@ int PrefDiag::run(){
 }
 
 
+// ダイアログのサイズをデフォルトのスクリーンに対する比率で設定する
+#if GTKMM_CHECK_VERSION(3,0,0)
+void PrefDiag::set_default_size_raito( double raito )
+{
+    const auto screen = Gdk::Screen::get_default();
+    const int width = static_cast< int >( screen->get_width() * raito );
+    const int height = static_cast< int >( screen->get_height() * raito );
+    Gtk::Dialog::set_default_size( width, height );
+}
+#endif
+
+
 // タイマーのslot関数
 bool PrefDiag::slot_timeout( int timer_number )
 {

--- a/src/skeleton/prefdiag.h
+++ b/src/skeleton/prefdiag.h
@@ -5,6 +5,8 @@
 #ifndef _PREFDIAG_H
 #define _PREFDIAG_H
 
+#include "gtkmmversion.h"
+
 #include <gtkmm.h>
 
 #include "jdlib/timeout.h"
@@ -45,6 +47,10 @@ namespace SKELETON
         virtual void slot_ok_clicked(){}
         virtual void slot_cancel_clicked(){}
         virtual void slot_apply_clicked(){}
+
+#if GTKMM_CHECK_VERSION(3,0,0)
+        void set_default_size_raito( double raito );
+#endif
 
       private:
 

--- a/src/skeleton/selectitempref.cpp
+++ b/src/skeleton/selectitempref.cpp
@@ -1,6 +1,7 @@
 // ライセンス: GPL2
 
 //#define _DEBUG
+#include "gtkmmversion.h"
 #include "jddebug.h"
 
 #include "selectitempref.h"
@@ -10,6 +11,10 @@
 
 #include "global.h"
 #include "session.h"
+
+#if GTKMM_CHECK_VERSION(3,0,0)
+#include <gdk/gdkkeysyms-compat.h>
+#endif
 
 using namespace SKELETON;
 

--- a/src/skeleton/selectitempref.cpp
+++ b/src/skeleton/selectitempref.cpp
@@ -391,8 +391,8 @@ void SelectItemPref::slot_top()
     // 移動先のイテレータ
     Gtk::TreeIter upper_it = children.begin();
 
-    std::list< Gtk::TreePath > selection_path = m_tree_shown.get_selection()->get_selected_rows();
-    std::list< Gtk::TreePath >::iterator it = selection_path.begin();
+    std::vector< Gtk::TreePath > selection_path = m_tree_shown.get_selection()->get_selected_rows();
+    std::vector< Gtk::TreePath >::iterator it = selection_path.begin();
     while( it != selection_path.end() )
     {
         Gtk::TreeIter src_it = m_store_shown->get_iter( *it );
@@ -428,8 +428,8 @@ void SelectItemPref::slot_up()
     // 上限のイテレータ
     Gtk::TreeIter upper_it = children.begin();
 
-    std::list< Gtk::TreePath > selection_path = m_tree_shown.get_selection()->get_selected_rows();
-    std::list< Gtk::TreePath >::iterator it = selection_path.begin();
+    std::vector< Gtk::TreePath > selection_path = m_tree_shown.get_selection()->get_selected_rows();
+    std::vector< Gtk::TreePath >::iterator it = selection_path.begin();
     while( it != selection_path.end() )
     {
         Gtk::TreePath src = *it;
@@ -469,8 +469,8 @@ void SelectItemPref::slot_down()
     // 下限のイテレータ
     Gtk::TreeIter bottom_it = --children.end();
 
-    std::list< Gtk::TreePath > selection_path = m_tree_shown.get_selection()->get_selected_rows();
-    std::list< Gtk::TreePath >::reverse_iterator it = selection_path.rbegin();
+    std::vector< Gtk::TreePath > selection_path = m_tree_shown.get_selection()->get_selected_rows();
+    std::vector< Gtk::TreePath >::reverse_iterator it = selection_path.rbegin();
     while( it != selection_path.rend() )
     {
         Gtk::TreePath src = *it;
@@ -512,8 +512,8 @@ void SelectItemPref::slot_bottom()
     // 移動先のイテレータ
     Gtk::TreeIter bottom_it = children.end();
 
-    std::list< Gtk::TreePath > selection_path = m_tree_shown.get_selection()->get_selected_rows();
-    std::list< Gtk::TreePath >::reverse_iterator it = selection_path.rbegin();
+    std::vector< Gtk::TreePath > selection_path = m_tree_shown.get_selection()->get_selected_rows();
+    std::vector< Gtk::TreePath >::reverse_iterator it = selection_path.rbegin();
     while( it != selection_path.rend() )
     {
         Gtk::TreeIter src_it = m_store_shown->get_iter( *it );
@@ -543,7 +543,7 @@ void SelectItemPref::slot_bottom()
 //
 void SelectItemPref::slot_delete()
 {
-    std::list< Gtk::TreePath > selection_path = m_tree_shown.get_selection()->get_selected_rows();
+    std::vector< Gtk::TreePath > selection_path = m_tree_shown.get_selection()->get_selected_rows();
 
     // 選択したアイテムが無い場合はフォーカスだけ移して出る
     if( selection_path.empty() )
@@ -555,7 +555,7 @@ void SelectItemPref::slot_delete()
     std::list< Gtk::TreeRow > erase_rows;
     bool set_cursor = true;  // 一番上の選択項目にカーソルをセット
 
-    std::list< Gtk::TreePath >::iterator it = selection_path.begin();
+    std::vector< Gtk::TreePath >::iterator it = selection_path.begin();
     while( it != selection_path.end() )
     {
         Gtk::TreePath path = *it;
@@ -598,7 +598,7 @@ void SelectItemPref::slot_delete()
 //
 void SelectItemPref::slot_add()
 {
-    std::list< Gtk::TreePath > selection_path = m_tree_hidden.get_selection()->get_selected_rows();
+    std::vector< Gtk::TreePath > selection_path = m_tree_hidden.get_selection()->get_selected_rows();
 
     // 選択したアイテムが無い場合はフォーカスだけ移して出る
     if( selection_path.empty() )
@@ -611,7 +611,7 @@ void SelectItemPref::slot_add()
     bool set_cursor = true; // 一番上の選択項目にカーソルをセット
 
     // 選択したアイテムを追加
-    std::list< Gtk::TreePath >::iterator it = selection_path.begin();
+    std::vector< Gtk::TreePath >::iterator it = selection_path.begin();
     while( it != selection_path.end() )
     {
         Gtk::TreeRow row = *m_store_hidden->get_iter( *it );

--- a/src/skeleton/selectitempref.cpp
+++ b/src/skeleton/selectitempref.cpp
@@ -108,7 +108,7 @@ void SelectItemPref::pack_widgets()
     m_vbuttonbox_v.set_spacing( 4 );
     m_vbox.pack_start( m_vbuttonbox_v, Gtk::PACK_EXPAND_WIDGET );
 
-    m_vbuttonbox_h.set_layout( Gtk::BUTTONBOX_DEFAULT_STYLE );
+    m_vbuttonbox_h.set_layout( Gtk::BUTTONBOX_EDGE );
     m_vbuttonbox_h.set_spacing( 4 );
     m_vbox.pack_start( m_vbuttonbox_h, Gtk::PACK_SHRINK );
 

--- a/src/skeleton/tablabel.cpp
+++ b/src/skeleton/tablabel.cpp
@@ -29,8 +29,10 @@ TabLabel::TabLabel( const std::string& url )
     // 背景透過
     set_visible_window( false );
 
+#if !GTKMM_CHECK_VERSION(2,10,0)
     add_events( Gdk::POINTER_MOTION_MASK );
     add_events( Gdk::LEAVE_NOTIFY_MASK );
+#endif
 
     add( m_hbox );
     m_hbox.pack_start( m_label, Gtk::PACK_SHRINK );
@@ -75,6 +77,15 @@ void TabLabel::set_id_icon( const int id )
 }
 
 
+#if GTKMM_CHECK_VERSION(2,10,0)
+void TabLabel::set_fulltext( const std::string& label )
+{
+    m_fulltext = label;
+    set_tooltip_text( m_fulltext );
+}
+#endif // GTKMM_CHECK_VERSION(2,10,0)
+
+
 // タブの文字列の文字数がlngになるようにリサイズする
 void TabLabel::resize_tab( const unsigned int lng )
 {
@@ -89,6 +100,7 @@ void TabLabel::resize_tab( const unsigned int lng )
 //
 // D&D設定
 //
+#if !GTKMM_CHECK_VERSION(2,10,0)
 void TabLabel::set_dragable( bool dragable, int button )
 {
     if( dragable ){
@@ -112,6 +124,7 @@ void TabLabel::set_dragable( bool dragable, int button )
         drag_dest_unset();
     }
 }
+#endif // !GTKMM_CHECK_VERSION(2,10,0)
 
 
 //
@@ -144,6 +157,7 @@ const int TabLabel::get_label_margin()
 //
 // マウスが動いた
 //
+#if !GTKMM_CHECK_VERSION(2,10,0)
 bool TabLabel::on_motion_notify_event( GdkEventMotion* event )
 {
     const bool ret = Gtk::EventBox::on_motion_notify_event( event );
@@ -152,11 +166,13 @@ bool TabLabel::on_motion_notify_event( GdkEventMotion* event )
 
     return ret;
 }
+#endif // !GTKMM_CHECK_VERSION(2,10,0)
 
 
 //
 // マウスが出た
 //
+#if !GTKMM_CHECK_VERSION(2,10,0)
 bool TabLabel::on_leave_notify_event( GdkEventCrossing* event )
 {
 #ifdef _DEBUG
@@ -169,11 +185,13 @@ bool TabLabel::on_leave_notify_event( GdkEventCrossing* event )
 
     return ret;
 }
+#endif // !GTKMM_CHECK_VERSION(2,10,0)
 
 
 //
 // ドラッグ開始
 //
+#if !GTKMM_CHECK_VERSION(2,10,0)
 void TabLabel::on_drag_begin( const Glib::RefPtr< Gdk::DragContext >& context )
 {
 #ifdef _DEBUG
@@ -184,11 +202,13 @@ void TabLabel::on_drag_begin( const Glib::RefPtr< Gdk::DragContext >& context )
 
     Gtk::EventBox::on_drag_begin( context );
 }
+#endif // !GTKMM_CHECK_VERSION(2,10,0)
 
 
 //
 // D&Dで受信側がデータ送信を要求してきた
 //
+#if !GTKMM_CHECK_VERSION(2,10,0)
 void TabLabel::on_drag_data_get( const Glib::RefPtr<Gdk::DragContext>& context,
                                  Gtk::SelectionData& selection_data, guint info, guint time )
 {
@@ -201,11 +221,13 @@ void TabLabel::on_drag_data_get( const Glib::RefPtr<Gdk::DragContext>& context,
 
     m_sig_tab_drag_data_get( selection_data );
 }
+#endif // !GTKMM_CHECK_VERSION(2,10,0)
 
 
 //
 // ドラッグ終了
 //
+#if !GTKMM_CHECK_VERSION(2,10,0)
 void TabLabel::on_drag_end( const Glib::RefPtr< Gdk::DragContext >& context )
 {
 #ifdef _DEBUG
@@ -216,3 +238,4 @@ void TabLabel::on_drag_end( const Glib::RefPtr< Gdk::DragContext >& context )
 
     m_sig_tab_drag_end.emit();
 }
+#endif // !GTKMM_CHECK_VERSION(2,10,0)

--- a/src/skeleton/tablabel.cpp
+++ b/src/skeleton/tablabel.cpp
@@ -29,7 +29,10 @@ TabLabel::TabLabel( const std::string& url )
     // 背景透過
     set_visible_window( false );
 
-#if !GTKMM_CHECK_VERSION(2,10,0)
+#if GTKMM_CHECK_VERSION(2,10,0)
+    add_events( Gdk::BUTTON_PRESS_MASK );
+    add_events( Gdk::BUTTON_RELEASE_MASK );
+#else
     add_events( Gdk::POINTER_MOTION_MASK );
     add_events( Gdk::LEAVE_NOTIFY_MASK );
 #endif
@@ -239,3 +242,31 @@ void TabLabel::on_drag_end( const Glib::RefPtr< Gdk::DragContext >& context )
     m_sig_tab_drag_end.emit();
 }
 #endif // !GTKMM_CHECK_VERSION(2,10,0)
+
+
+#if GTKMM_CHECK_VERSION(2,10,0)
+bool TabLabel::on_button_press_event( GdkEventButton* event )
+{
+#ifdef _DEBUG
+    std::cout << "TabLabel::on_button_press_event " << m_fulltext << std::endl;
+#endif
+
+    Gtk::EventBox::on_button_press_event( event );
+
+    return m_sig_tab_button_press_event.emit( event, this );
+}
+#endif // GTKMM_CHECK_VERSION(2,10,0)
+
+
+#if GTKMM_CHECK_VERSION(2,10,0)
+bool TabLabel::on_button_release_event( GdkEventButton* event )
+{
+#ifdef _DEBUG
+    std::cout << "TabLabel::on_button_release_event " << m_fulltext << std::endl;
+#endif
+
+    Gtk::EventBox::on_button_release_event( event );
+
+    return m_sig_tab_button_release_event.emit( event, this );
+}
+#endif // GTKMM_CHECK_VERSION(2,10,0)

--- a/src/skeleton/tablabel.cpp
+++ b/src/skeleton/tablabel.cpp
@@ -93,7 +93,7 @@ void TabLabel::set_dragable( bool dragable, int button )
 {
     if( dragable ){
 
-        std::list< Gtk::TargetEntry > targets;
+        std::vector< Gtk::TargetEntry > targets;
         targets.push_back( Gtk::TargetEntry( DNDTARGET_FAVORITE, Gtk::TARGET_SAME_APP, 0 ) );
         targets.push_back( Gtk::TargetEntry( DNDTARGET_TAB, Gtk::TARGET_SAME_APP, 0 ) );
 

--- a/src/skeleton/tablabel.h
+++ b/src/skeleton/tablabel.h
@@ -10,7 +10,10 @@
 
 namespace SKELETON
 {
-#if !GTKMM_CHECK_VERSION(2,10,0)
+#if GTKMM_CHECK_VERSION(2,10,0)
+    typedef sigc::signal< bool, GdkEventButton*, Gtk::Widget* > SIG_TAB_BUTTON_PRESS_EVENT;
+    typedef sigc::signal< bool, GdkEventButton*, Gtk::Widget* > SIG_TAB_BUTTON_RELEASE_EVENT;
+#else
     // マウス
     typedef sigc::signal< void > SIG_TAB_MOTION_EVENT;
     typedef sigc::signal< void > SIG_TAB_LEAVE_EVENT;
@@ -19,23 +22,29 @@ namespace SKELETON
     typedef sigc::signal< void > SIG_TAB_DRAG_BEGIN;
     typedef sigc::signal< void, Gtk::SelectionData& > SIG_TAB_DRAG_DATA_GET;
     typedef sigc::signal< void > SIG_TAB_DRAG_END;
-#endif // !GTKMM_CHECK_VERSION(2,10,0)
+#endif // GTKMM_CHECK_VERSION(2,10,0)
 
     class TabLabel : public Gtk::EventBox
     {
-#if !GTKMM_CHECK_VERSION(2,10,0)
+#if GTKMM_CHECK_VERSION(2,10,0)
+        SIG_TAB_BUTTON_PRESS_EVENT m_sig_tab_button_press_event;
+        SIG_TAB_BUTTON_RELEASE_EVENT m_sig_tab_button_release_event;
+#else
+
         SIG_TAB_MOTION_EVENT m_sig_tab_motion_event;
         SIG_TAB_LEAVE_EVENT m_sig_tab_leave_event;
 
         SIG_TAB_DRAG_BEGIN m_sig_tab_drag_begin;
         SIG_TAB_DRAG_DATA_GET m_sig_tab_drag_data_get;
         SIG_TAB_DRAG_END m_sig_tab_drag_end;
-#endif // !GTKMM_CHECK_VERSION(2,10,0)
+#endif // GTKMM_CHECK_VERSION(2,10,0)
 
+#if !GTKMM_CHECK_VERSION(2,10,0)
         int m_x;
         int m_y;
         int m_width;
         int m_height;
+#endif // !GTKMM_CHECK_VERSION(2,10,0)
 
         std::string m_url;
         Gtk::HBox m_hbox;
@@ -54,15 +63,25 @@ namespace SKELETON
         TabLabel( const std::string& url );
         virtual ~TabLabel();
 
-#if !GTKMM_CHECK_VERSION(2,10,0)
+#if GTKMM_CHECK_VERSION(2,10,0)
+        SIG_TAB_BUTTON_PRESS_EVENT sig_tab_button_press_event()
+        {
+            return m_sig_tab_button_press_event;
+        }
+        SIG_TAB_BUTTON_RELEASE_EVENT sig_tab_button_release_event()
+        {
+            return m_sig_tab_button_release_event;
+        }
+#else
         SIG_TAB_MOTION_EVENT sig_tab_motion_event(){ return  m_sig_tab_motion_event; }
         SIG_TAB_LEAVE_EVENT sig_tab_leave_event(){ return m_sig_tab_leave_event; }
 
         SIG_TAB_DRAG_BEGIN sig_tab_drag_begin() { return m_sig_tab_drag_begin; }
         SIG_TAB_DRAG_DATA_GET sig_tab_drag_data_get() { return m_sig_tab_drag_data_get; }
         SIG_TAB_DRAG_END sig_tab_drag_end() { return m_sig_tab_drag_end; }
-#endif // !GTKMM_CHECK_VERSION(2,10,0)
+#endif // GTKMM_CHECK_VERSION(2,10,0)
 
+#if !GTKMM_CHECK_VERSION(2,10,0)
         const int get_tab_x() const { return m_x; }
         const int get_tab_y() const { return m_y; }
         const int get_tab_width() const { return m_width; }
@@ -72,6 +91,7 @@ namespace SKELETON
         void set_tab_y( const int y ){ m_y = y; }
         void set_tab_width( const int width ){ m_width = width; }
         void set_tab_height( const int height ){ m_height = height; }
+#endif // !GTKMM_CHECK_VERSION(2,10,0)
 
         Pango::FontDescription get_label_font_description(){
             return m_label.get_pango_context()->get_font_description(); }
@@ -100,9 +120,12 @@ namespace SKELETON
         // タブの文字列の文字数をlngにセット
         void resize_tab( const unsigned int lng );
 
-#if !GTKMM_CHECK_VERSION(2,10,0)
       private:
 
+#if GTKMM_CHECK_VERSION(2,10,0)
+        virtual bool on_button_press_event( GdkEventButton* event );
+        virtual bool on_button_release_event( GdkEventButton* event );
+#else
         virtual bool on_motion_notify_event( GdkEventMotion* event );
         virtual bool on_leave_notify_event( GdkEventCrossing* event );
 
@@ -110,7 +133,7 @@ namespace SKELETON
         virtual void on_drag_data_get( const Glib::RefPtr<Gdk::DragContext>& context,
                                        Gtk::SelectionData& selection_data, guint info, guint time );
         virtual void on_drag_end( const Glib::RefPtr< Gdk::DragContext>& context );
-#endif // !GTKMM_CHECK_VERSION(2,10,0)
+#endif // GTKMM_CHECK_VERSION(2,10,0)
     }; 
 }
 

--- a/src/skeleton/tablabel.h
+++ b/src/skeleton/tablabel.h
@@ -3,11 +3,14 @@
 #ifndef _TABLABEL_H
 #define _TABLABEL_H
 
+#include "gtkmmversion.h"
+
 #include <gtkmm.h>
 #include <string>
 
 namespace SKELETON
 {
+#if !GTKMM_CHECK_VERSION(2,10,0)
     // マウス
     typedef sigc::signal< void > SIG_TAB_MOTION_EVENT;
     typedef sigc::signal< void > SIG_TAB_LEAVE_EVENT;
@@ -16,15 +19,18 @@ namespace SKELETON
     typedef sigc::signal< void > SIG_TAB_DRAG_BEGIN;
     typedef sigc::signal< void, Gtk::SelectionData& > SIG_TAB_DRAG_DATA_GET;
     typedef sigc::signal< void > SIG_TAB_DRAG_END;
+#endif // !GTKMM_CHECK_VERSION(2,10,0)
 
     class TabLabel : public Gtk::EventBox
     {
+#if !GTKMM_CHECK_VERSION(2,10,0)
         SIG_TAB_MOTION_EVENT m_sig_tab_motion_event;
         SIG_TAB_LEAVE_EVENT m_sig_tab_leave_event;
 
         SIG_TAB_DRAG_BEGIN m_sig_tab_drag_begin;
         SIG_TAB_DRAG_DATA_GET m_sig_tab_drag_data_get;
         SIG_TAB_DRAG_END m_sig_tab_drag_end;
+#endif // !GTKMM_CHECK_VERSION(2,10,0)
 
         int m_x;
         int m_y;
@@ -48,12 +54,14 @@ namespace SKELETON
         TabLabel( const std::string& url );
         virtual ~TabLabel();
 
+#if !GTKMM_CHECK_VERSION(2,10,0)
         SIG_TAB_MOTION_EVENT sig_tab_motion_event(){ return  m_sig_tab_motion_event; }
         SIG_TAB_LEAVE_EVENT sig_tab_leave_event(){ return m_sig_tab_leave_event; }
 
         SIG_TAB_DRAG_BEGIN sig_tab_drag_begin() { return m_sig_tab_drag_begin; }
         SIG_TAB_DRAG_DATA_GET sig_tab_drag_data_get() { return m_sig_tab_drag_data_get; }
         SIG_TAB_DRAG_END sig_tab_drag_end() { return m_sig_tab_drag_end; }
+#endif // !GTKMM_CHECK_VERSION(2,10,0)
 
         const int get_tab_x() const { return m_x; }
         const int get_tab_y() const { return m_y; }
@@ -70,14 +78,20 @@ namespace SKELETON
 
         const std::string& get_url(){ return m_url; }
 
+#if !GTKMM_CHECK_VERSION(2,10,0)
         void set_dragable( bool dragable, int button );
+#endif
 
         // 本体の横幅 - ラベルの横幅
         const int get_label_margin();
 
         // カットしていない全体の文字列
         const std::string& get_fulltext() const { return m_fulltext; }
+#if GTKMM_CHECK_VERSION(2,10,0)
+        void set_fulltext( const std::string& label );
+#else
         void set_fulltext( const std::string& label ){ m_fulltext = label; }
+#endif
 
         // アイコンセット
         void set_id_icon( const int id );
@@ -86,6 +100,7 @@ namespace SKELETON
         // タブの文字列の文字数をlngにセット
         void resize_tab( const unsigned int lng );
 
+#if !GTKMM_CHECK_VERSION(2,10,0)
       private:
 
         virtual bool on_motion_notify_event( GdkEventMotion* event );
@@ -95,6 +110,7 @@ namespace SKELETON
         virtual void on_drag_data_get( const Glib::RefPtr<Gdk::DragContext>& context,
                                        Gtk::SelectionData& selection_data, guint info, guint time );
         virtual void on_drag_end( const Glib::RefPtr< Gdk::DragContext>& context );
+#endif // !GTKMM_CHECK_VERSION(2,10,0)
     }; 
 }
 

--- a/src/skeleton/tabnote.cpp
+++ b/src/skeleton/tabnote.cpp
@@ -18,6 +18,8 @@
 
 using namespace SKELETON;
 
+#if !GTKMM_CHECK_VERSION(3,0,0)
+
 //////////////////////////////////////////
 //
 // gtknotebook.c( Revision 19311, 2008-01-06 ) より引用
@@ -97,6 +99,8 @@ struct _GtkNotebookPage
   gulong mnemonic_activate_signal;
   gulong notify_visible_handler;
 };
+
+#endif // !GTKMM_CHECK_VERSION(3,0,0)
 
 
 //////////////////////////////////////////
@@ -831,6 +835,7 @@ bool TabNotebook::adjust_tabwidth()
 //
 // タブの高さ、幅、位置を取得 ( 描画用 )
 //
+#if !GTKMM_CHECK_VERSION(3,0,0)
 void TabNotebook::get_alloc_tab( Alloc_NoteBook& alloc )
 {
     alloc.x_tab = 0;
@@ -850,6 +855,7 @@ void TabNotebook::get_alloc_tab( Alloc_NoteBook& alloc )
         alloc.height_tab = notebook->cur_page->allocation.height;
     }
 }
+#endif // !GTKMM_CHECK_VERSION(3,0,0)
 
 
 //

--- a/src/skeleton/tabnote.cpp
+++ b/src/skeleton/tabnote.cpp
@@ -635,6 +635,13 @@ void TabNotebook::set_tab_fulltext( const std::string& str, int page )
         tablabel->set_fulltext( str );
         if( m_fixtab ) tablabel->resize_tab( str.length() );
         else adjust_tabwidth();
+#if GTKMM_CHECK_VERSION(3,0,0)
+        if( m_parent->get_timeout_drawn() ) {
+            // XXX: ArticleAdminのタブを描画するためタイマーを設定する
+            // DAT取得済のスレを開くと他のタブのラベルが消える不具合を回避する
+            m_parent->start_draw_timer( this, TIMEOUT_DRAWN_SET_TAB_FULLTEXT );
+        }
+#endif
     }
 }
 

--- a/src/skeleton/tabnote.cpp
+++ b/src/skeleton/tabnote.cpp
@@ -105,6 +105,7 @@ struct _GtkNotebookPage
 
 
 // 描画本体
+#if !GTKMM_CHECK_VERSION(2,10,0)
 const bool TabNotebook::paint( GdkEventExpose* event )
 {
     GtkNotebook *notebook = gobj();
@@ -202,9 +203,11 @@ const bool TabNotebook::paint( GdkEventExpose* event )
 
     return true;
 }
+#endif // !GTKMM_CHECK_VERSION(2,10,0)
 
 
 // タブ描画
+#if !GTKMM_CHECK_VERSION(2,10,0)
 void TabNotebook::draw_tab( const GtkNotebook *notebook,
                             const GtkNotebookPage *page,
                             GdkRectangle *area,
@@ -249,9 +252,11 @@ void TabNotebook::draw_tab( const GtkNotebook *notebook,
             );
     }
 }
+#endif // !GTKMM_CHECK_VERSION(2,10,0)
 
 
 // 矢印(スクロール)マークの描画
+#if !GTKMM_CHECK_VERSION(2,10,0)
 void TabNotebook::draw_arrow( GtkWidget *widget,
                               const GtkNotebook *notebook,
                               const Gdk::Rectangle& rect,
@@ -302,10 +307,12 @@ void TabNotebook::draw_arrow( GtkWidget *widget,
                               arrow_rect.height
         );
 }
+#endif // !GTKMM_CHECK_VERSION(2,10,0)
 
 
 // 矢印マークの位置、幅、高さを取得
 // before : true ならタブの左側に表示される矢印
+#if !GTKMM_CHECK_VERSION(2,10,0)
 void TabNotebook::get_arrow_rect( GtkWidget *widget, const GtkNotebook *notebook, GdkRectangle *rectangle, const gboolean before )
 {
     GdkRectangle event_window_pos;
@@ -327,9 +334,11 @@ void TabNotebook::get_arrow_rect( GtkWidget *widget, const GtkNotebook *notebook
         rectangle->y = event_window_pos.y + ( event_window_pos.height - rectangle->height ) / 2;
     }
 }
+#endif // !GTKMM_CHECK_VERSION(2,10,0)
 
 
 // タブ描画領域の位置、幅、高さを取得
+#if !GTKMM_CHECK_VERSION(2,10,0)
 const gboolean TabNotebook::get_event_window_position( const GtkWidget *widget, const GtkNotebook *notebook, GdkRectangle *rectangle )
 {
     GtkNotebookPage* visible_page = NULL;
@@ -363,6 +372,7 @@ const gboolean TabNotebook::get_event_window_position( const GtkWidget *widget, 
 
     return FALSE;
 }
+#endif // !GTKMM_CHECK_VERSION(2,10,0)
 
 
 
@@ -400,9 +410,12 @@ TabNotebook::TabNotebook( DragableNoteBook* parent )
     set_border_width( 0 );
     set_size_request( 1, -1 ); // これが無いと最大化を解除したときにウィンドウが勝手にリサイズする
 
+#if !GTKMM_CHECK_VERSION(2,10,0)
     add_events( Gdk::POINTER_MOTION_MASK );
     add_events( Gdk::LEAVE_NOTIFY_MASK );
+#endif
 
+#if !GTKMM_CHECK_VERSION(2,10,0)
     // DnD設定
     // ドロップ側に設定する
     drag_source_unset();
@@ -410,6 +423,7 @@ TabNotebook::TabNotebook( DragableNoteBook* parent )
     std::list< Gtk::TargetEntry > targets;
     targets.push_back( Gtk::TargetEntry( DNDTARGET_TAB, Gtk::TARGET_SAME_APP, 0 ) );
     drag_dest_set( targets, Gtk::DEST_DEFAULT_MOTION | Gtk::DEST_DEFAULT_DROP );
+#endif // !GTKMM_CHECK_VERSION(2,10,0)
 
     Glib::RefPtr< Gtk::RcStyle > rcst = get_modifier_style();
     Glib::RefPtr< Gtk::Style > st = get_style();
@@ -814,10 +828,12 @@ void TabNotebook::get_alloc_tab( Alloc_NoteBook& alloc )
 //
 // 描画イベント
 //
+#if !GTKMM_CHECK_VERSION(2,10,0)
 bool TabNotebook::on_expose_event( GdkEventExpose* event )
 {
     return paint( event );
 }
+#endif // !GTKMM_CHECK_VERSION(2,10,0)
 
 
 
@@ -858,6 +874,7 @@ bool TabNotebook::on_button_release_event( GdkEventButton* event )
 //
 // マウスが動いた
 //
+#if !GTKMM_CHECK_VERSION(2,10,0)
 bool TabNotebook::on_motion_notify_event( GdkEventMotion* event )
 {
 #ifdef _DEBUG
@@ -868,11 +885,13 @@ bool TabNotebook::on_motion_notify_event( GdkEventMotion* event )
 
     return Gtk::Notebook::on_motion_notify_event( event );
 }
+#endif // !GTKMM_CHECK_VERSION(2,10,0)
 
 
 //
 // マウスが出た
 //
+#if !GTKMM_CHECK_VERSION(2,10,0)
 bool TabNotebook::on_leave_notify_event( GdkEventCrossing* event )
 {
 #ifdef _DEBUG
@@ -883,11 +902,13 @@ bool TabNotebook::on_leave_notify_event( GdkEventCrossing* event )
 
     return Gtk::Notebook::on_leave_notify_event( event );
 }
+#endif // !GTKMM_CHECK_VERSION(2,10,0)
 
 
 //
 // マウスホイールを回した
 //
+#if !GTKMM_CHECK_VERSION(2,10,0)
 bool TabNotebook::on_scroll_event( GdkEventScroll* event )
 {
     if( ! CONFIG::get_switchtab_wheel() ) return true;
@@ -900,11 +921,13 @@ bool TabNotebook::on_scroll_event( GdkEventScroll* event )
 
     return Gtk::Notebook::on_scroll_event( event );
 }
+#endif // !GTKMM_CHECK_VERSION(2,10,0)
 
 
 //
 // ドラッグ中にマウスを動かした
 //
+#if !GTKMM_CHECK_VERSION(2,10,0)
 bool TabNotebook::on_drag_motion( const Glib::RefPtr<Gdk::DragContext>& context, int x, int y, guint time)
 {
 #ifdef _DEBUG
@@ -939,3 +962,4 @@ bool TabNotebook::on_drag_motion( const Glib::RefPtr<Gdk::DragContext>& context,
     // on_drag_motion をキャンセルしないとDnD中にタブが勝手に切り替わる( gtknotebook.c をハック )
     return true;
 }
+#endif // !GTKMM_CHECK_VERSION(2,10,0)

--- a/src/skeleton/tabnote.cpp
+++ b/src/skeleton/tabnote.cpp
@@ -425,11 +425,22 @@ TabNotebook::TabNotebook( DragableNoteBook* parent )
     drag_dest_set( targets, Gtk::DEST_DEFAULT_MOTION | Gtk::DEST_DEFAULT_DROP );
 #endif // !GTKMM_CHECK_VERSION(2,10,0)
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+#if GTKMM_CHECK_VERSION(3,12,0)
+    m_tab_mrg = get_margin_top();
+#else
+    m_tab_mrg = get_margin_left();
+#endif
+    if( m_tab_mrg <= 0 ) {
+        m_tab_mrg = get_style_context()->get_margin().get_left();
+    }
+#else
     Glib::RefPtr< Gtk::RcStyle > rcst = get_modifier_style();
     Glib::RefPtr< Gtk::Style > st = get_style();
 
     m_tab_mrg = rcst->get_xthickness() * 2;
     if( m_tab_mrg <= 0 ) m_tab_mrg = st->get_xthickness() * 2;
+#endif // GTKMM_CHECK_VERSION(3,0,0)
 
     m_pre_width = get_width();
 }

--- a/src/skeleton/tabnote.cpp
+++ b/src/skeleton/tabnote.cpp
@@ -448,7 +448,9 @@ void TabNotebook::clock_in()
         && ! SESSION::is_quitting()
         ){
 
+#if !GTKMM_CHECK_VERSION(2,10,0)
         calc_tabsize();
+#endif
         adjust_tabwidth();
     }
 }
@@ -530,6 +532,17 @@ SKELETON::TabLabel* TabNotebook::get_tablabel( int page )
 //
 const int TabNotebook::get_page_under_mouse()
 {
+#if GTKMM_CHECK_VERSION(2,10,0)
+    // TabLabelの領域外をクリックしたときm_button_event_tabは更新されない
+    // 誤動作を防ぐためフィールドを無効な値にリセットする
+    const int tab = m_button_event_tab;
+    m_button_event_tab = -1;
+#ifdef _DEBUG
+    std::cout << "TabNotebook::get_page_under_mouse tab = " << tab << std::endl;
+#endif
+    return tab;
+#else
+
     int x, y;
     Gdk::Rectangle rect = get_allocation();
     get_pointer( x, y );
@@ -576,6 +589,7 @@ const int TabNotebook::get_page_under_mouse()
 #endif
 
     return ret;
+#endif // GTKMM_CHECK_VERSION(2,10,0)
 }
 
 
@@ -613,6 +627,7 @@ void TabNotebook::set_tab_fulltext( const std::string& str, int page )
 //
 // 各タブのサイズと座標を取得
 //
+#if !GTKMM_CHECK_VERSION(2,10,0)
 void TabNotebook::calc_tabsize()
 {
 #ifdef _DEBUG
@@ -659,6 +674,7 @@ void TabNotebook::calc_tabsize()
         }
     }
 }
+#endif // !GTKMM_CHECK_VERSION(2,10,0)
 
 
 //
@@ -963,3 +979,24 @@ bool TabNotebook::on_drag_motion( const Glib::RefPtr<Gdk::DragContext>& context,
     return true;
 }
 #endif // !GTKMM_CHECK_VERSION(2,10,0)
+
+
+#if GTKMM_CHECK_VERSION(2,10,0)
+bool TabNotebook::slot_tab_button_event( GdkEventButton*, Gtk::Widget* widget )
+{
+    const int n_pages = get_n_pages();
+    m_button_event_tab = -1;
+    for( int n = 0; n < n_pages; ++n ) {
+        Gtk::Widget* tab = get_tab_label( *get_nth_page( n ) );
+        if( tab == widget ) {
+            m_button_event_tab = n;
+            break;
+        }
+    }
+#ifdef _DEBUG
+    std::cout << "TabNotebook::slot_tab_button_event "
+              << "m_button_event_tab = " << m_button_event_tab << std::endl;
+#endif
+    return false;
+}
+#endif // GTKMM_CHECK_VERSION(2,10,0)

--- a/src/skeleton/tabnote.h
+++ b/src/skeleton/tabnote.h
@@ -63,6 +63,10 @@ namespace SKELETON
 
         const std::string m_str_empty;
 
+#if GTKMM_CHECK_VERSION(2,10,0)
+        int m_button_event_tab = -1;
+#endif
+
     public:
 
         SIG_BUTTON_PRESS sig_button_press(){ return m_sig_button_press; }
@@ -107,6 +111,10 @@ namespace SKELETON
         // タブの高さ、幅、位置を取得 ( 描画用 )
         void get_alloc_tab( Alloc_NoteBook& alloc );
 
+#if GTKMM_CHECK_VERSION(2,10,0)
+        bool slot_tab_button_event( GdkEventButton*, Gtk::Widget* widget );
+#endif
+
       private:
 
 #if !GTKMM_CHECK_VERSION(2,10,0)
@@ -131,8 +139,10 @@ namespace SKELETON
 #endif // !GTKMM_CHECK_VERSION(2,10,0)
 
 
+#if !GTKMM_CHECK_VERSION(2,10,0)
         // 各タブのサイズと座標を取得
         void calc_tabsize();
+#endif
 
       protected:
 

--- a/src/skeleton/tabnote.h
+++ b/src/skeleton/tabnote.h
@@ -25,6 +25,7 @@ namespace SKELETON
     typedef sigc::signal< bool, GdkEventButton* > SIG_BUTTON_PRESS;
     typedef sigc::signal< bool, GdkEventButton* > SIG_BUTTON_RELEASE;
 
+#if !GTKMM_CHECK_VERSION(2,10,0)
     // マウス移動
     typedef sigc::signal< void > SIG_TAB_MOTION_EVENT;
     typedef sigc::signal< void > SIG_TAB_LEAVE_EVENT;
@@ -34,6 +35,7 @@ namespace SKELETON
 
     // D&D
     typedef sigc::signal< void, const int, const int, const int, const int > SIG_TAB_DRAG_MOTION;
+#endif // !GTKMM_CHECK_VERSION(2,10,0)
 
     // タブ用の Notebook
     class TabNotebook : public Gtk::Notebook
@@ -41,12 +43,14 @@ namespace SKELETON
         SIG_BUTTON_PRESS m_sig_button_press;
         SIG_BUTTON_RELEASE m_sig_button_release;
 
+#if !GTKMM_CHECK_VERSION(2,10,0)
         SIG_TAB_MOTION_EVENT m_sig_tab_motion_event;
         SIG_TAB_LEAVE_EVENT m_sig_tab_leave_event;
 
         SIG_TAB_DRAG_MOTION m_sig_tab_drag_motion;
 
         SIG_SCROLL_EVENT m_sig_scroll_event;
+#endif // !GTKMM_CHECK_VERSION(2,10,0)
 
         DragableNoteBook* m_parent;
 
@@ -64,12 +68,14 @@ namespace SKELETON
         SIG_BUTTON_PRESS sig_button_press(){ return m_sig_button_press; }
         SIG_BUTTON_RELEASE sig_button_release(){ return m_sig_button_release; }
 
+#if !GTKMM_CHECK_VERSION(2,10,0)
         SIG_TAB_MOTION_EVENT sig_tab_motion_event(){ return  m_sig_tab_motion_event; }
         SIG_TAB_LEAVE_EVENT sig_tab_leave_event(){ return m_sig_tab_leave_event; }
 
         SIG_TAB_DRAG_MOTION sig_tab_drag_motion(){ return m_sig_tab_drag_motion; }
 
         SIG_SCROLL_EVENT sig_scroll_event(){ return m_sig_scroll_event; }
+#endif // !GTKMM_CHECK_VERSION(2,10,0)
 
         TabNotebook( DragableNoteBook* parent );
 
@@ -103,6 +109,7 @@ namespace SKELETON
 
       private:
 
+#if !GTKMM_CHECK_VERSION(2,10,0)
         // gtknotebook.c ( Revision 19311, 2008-01-06 ) を参考にして作成した描画関係の関数
         const bool paint( GdkEventExpose* event );
 
@@ -121,6 +128,7 @@ namespace SKELETON
 
         void get_arrow_rect( GtkWidget *widget, const GtkNotebook *notebook, GdkRectangle *rectangle, const gboolean before );
         const gboolean get_event_window_position( const GtkWidget *widget, const GtkNotebook *notebook, GdkRectangle *rectangle );
+#endif // !GTKMM_CHECK_VERSION(2,10,0)
 
 
         // 各タブのサイズと座標を取得
@@ -128,7 +136,9 @@ namespace SKELETON
 
       protected:
 
+#if !GTKMM_CHECK_VERSION(2,10,0)
         virtual bool on_expose_event( GdkEventExpose* event );
+#endif
         virtual void on_size_allocate( Gtk::Allocation& allocation );
 
         // signal_button_press_event と signal_button_release_event は emit されない
@@ -136,11 +146,13 @@ namespace SKELETON
         virtual bool on_button_press_event( GdkEventButton* event );
         virtual bool on_button_release_event( GdkEventButton* event );
 
+#if !GTKMM_CHECK_VERSION(2,10,0)
         virtual bool on_motion_notify_event( GdkEventMotion* event );
         virtual bool on_leave_notify_event( GdkEventCrossing* event );
         virtual bool on_scroll_event( GdkEventScroll* event );
 
         virtual bool on_drag_motion( const Glib::RefPtr<Gdk::DragContext>& context, int x, int y, guint time);
+#endif // !GTKMM_CHECK_VERSION(2,10,0)
     };
 }
 

--- a/src/skeleton/tabnote.h
+++ b/src/skeleton/tabnote.h
@@ -6,7 +6,13 @@
 #ifndef _TABNOTE_H
 #define _TABNOTE_H
 
+#include "gtkmmversion.h"
+
 #include <gtkmm.h>
+
+#if GTKMM_CHECK_VERSION(3,0,0)
+using GtkNotebookPage = Gtk::Widget;
+#endif
 
 namespace SKELETON
 {

--- a/src/skeleton/tabnote.h
+++ b/src/skeleton/tabnote.h
@@ -108,8 +108,10 @@ namespace SKELETON
         // マウスがタブの右側にある場合はページ数の値を返す
         const int get_page_under_mouse();
 
+#if !GTKMM_CHECK_VERSION(3,0,0)
         // タブの高さ、幅、位置を取得 ( 描画用 )
         void get_alloc_tab( Alloc_NoteBook& alloc );
+#endif
 
 #if GTKMM_CHECK_VERSION(2,10,0)
         bool slot_tab_button_event( GdkEventButton*, Gtk::Widget* widget );

--- a/src/skeleton/tabswitchbutton.cpp
+++ b/src/skeleton/tabswitchbutton.cpp
@@ -64,6 +64,7 @@ void TabSwitchButton::hide_button()
 //
 // 自前でビュー領域の枠を描画する
 //
+#if !GTKMM_CHECK_VERSION(3,0,0)
 bool TabSwitchButton::on_expose_event( GdkEventExpose* event )
 {
     if( ! m_shown ) return Gtk::Notebook::on_expose_event( event );
@@ -76,3 +77,4 @@ bool TabSwitchButton::on_expose_event( GdkEventExpose* event )
 
     return true;
 }
+#endif // !GTKMM_CHECK_VERSION(3,0,0)

--- a/src/skeleton/tabswitchbutton.cpp
+++ b/src/skeleton/tabswitchbutton.cpp
@@ -23,9 +23,14 @@ TabSwitchButton::TabSwitchButton( DragableNoteBook* parent )
     m_button.set_focus_on_click( false );
 
     // フォーカス時にボタンの枠がはみ出さないようにする
+#if GTKMM_CHECK_VERSION(3,0,0)
+    m_button.set_margin_top( 0 );
+    m_button.set_margin_bottom( 0 );
+#else
     Glib::RefPtr< Gtk::RcStyle > rcst = m_button.get_modifier_style();
     rcst->set_ythickness( 0 );
     m_button.modify_style( rcst );
+#endif // GTKMM_CHECK_VERSION(3,0,0)
 
     m_vbox.pack_start( m_button, Gtk::PACK_SHRINK );
 

--- a/src/skeleton/tabswitchbutton.h
+++ b/src/skeleton/tabswitchbutton.h
@@ -35,9 +35,11 @@ namespace SKELETON
         void show_button();
         void hide_button();
 
+#if !GTKMM_CHECK_VERSION(3,0,0)
       protected:
 
         virtual bool on_expose_event( GdkEventExpose* event );
+#endif
     };
 }
 

--- a/src/skeleton/toolbar.cpp
+++ b/src/skeleton/toolbar.cpp
@@ -342,11 +342,12 @@ void ToolBar::set_color( const std::string& color )
     else{
 
         m_ebox_label->set_visible_window( true );
-        m_label->modify_fg( Gtk::STATE_NORMAL, Gdk::Color( "white" ) );
 #if GTKMM_CHECK_VERSION(3,0,0)
+        m_label->override_color( Gdk::RGBA( "white" ), Gtk::STATE_FLAG_NORMAL );
         m_ebox_label->override_background_color( Gdk::RGBA( color ), Gtk::STATE_FLAG_NORMAL );
         m_ebox_label->override_background_color( Gdk::RGBA( color ), Gtk::STATE_FLAG_ACTIVE );
 #else
+        m_label->modify_fg( Gtk::STATE_NORMAL, Gdk::Color( "white" ) );
         m_ebox_label->modify_bg( Gtk::STATE_NORMAL, Gdk::Color( color ) );
         m_ebox_label->modify_bg( Gtk::STATE_ACTIVE, Gdk::Color( color ) );
 #endif

--- a/src/skeleton/toolbar.cpp
+++ b/src/skeleton/toolbar.cpp
@@ -829,12 +829,10 @@ void ToolBar::slot_clicked_close()
     // ボタンに leave_notify イベントが送られないため、次にビューを開いたときに
     // 枠が残ったままになる
     //
-    // gtk+-2.12.9/gtk/gtkbutton.c の gtk_button_leave_notify() をハックして
-    // gtkbutton->in_button = false にすると枠が消えることが分かった
+    // 閉じるボタンに見えなくなることを通知して枠の描画をとめる
     if( m_admin->get_tab_nums() == 1 ){
         Gtk::Button* button = dynamic_cast< Gtk::Button* >( m_button_close->get_child() );
-        GtkButton* gtkbutton = button->gobj();
-        gtkbutton->in_button = false;
+        button->unmap();
     }
 
     m_admin->set_command( "toolbar_close_view", m_url );

--- a/src/skeleton/toolbar.cpp
+++ b/src/skeleton/toolbar.cpp
@@ -206,8 +206,8 @@ void ToolBar::update_button()
 // ボタンのアンパック
 void ToolBar::unpack_buttons()
 {
-    std::list< Gtk::Widget* > lists = m_buttonbar.get_children();
-    std::list< Gtk::Widget* >::iterator it = lists.begin();
+    std::vector< Gtk::Widget* > lists = m_buttonbar.get_children();
+    std::vector< Gtk::Widget* >::iterator it = lists.begin();
     for( ; it != lists.end(); ++it ){
         m_buttonbar.remove( *(*it) );
         if( dynamic_cast< Gtk::SeparatorToolItem* >( *it ) ) delete *it;
@@ -219,8 +219,8 @@ void ToolBar::unpack_search_buttons()
 {
     if( ! m_searchbar ) return;
 
-    std::list< Gtk::Widget* > lists = m_searchbar->get_children();
-    std::list< Gtk::Widget* >::iterator it = lists.begin();
+    std::vector< Gtk::Widget* > lists = m_searchbar->get_children();
+    std::vector< Gtk::Widget* >::iterator it = lists.begin();
     for( ; it != lists.end(); ++it ){
         m_searchbar->remove( *(*it) );
         if( dynamic_cast< Gtk::SeparatorToolItem* >( *it ) ) delete *it;
@@ -230,15 +230,15 @@ void ToolBar::unpack_search_buttons()
 // ボタンのrelief指定
 void ToolBar::set_relief()
 {
-    std::list< Gtk::Widget* > lists_toolbar = get_children();
-    std::list< Gtk::Widget* >::iterator it_toolbar = lists_toolbar.begin();
+    std::vector< Gtk::Widget* > lists_toolbar = get_children();
+    std::vector< Gtk::Widget* >::iterator it_toolbar = lists_toolbar.begin();
     for( ; it_toolbar != lists_toolbar.end(); ++it_toolbar ){
 
         Gtk::Toolbar* toolbar = dynamic_cast< Gtk::Toolbar* >( *it_toolbar );
         if( ! toolbar ) continue;
 
-        std::list< Gtk::Widget* > lists = toolbar->get_children();
-        std::list< Gtk::Widget* >::iterator it = lists.begin();
+        std::vector< Gtk::Widget* > lists = toolbar->get_children();
+        std::vector< Gtk::Widget* >::iterator it = lists.begin();
         for( ; it != lists.end(); ++it ){
 
             Gtk::Button* button = NULL;

--- a/src/skeleton/toolbar.cpp
+++ b/src/skeleton/toolbar.cpp
@@ -336,7 +336,11 @@ void ToolBar::set_color( const std::string& color )
 
         if( m_ebox_label->get_visible_window() ){
             m_ebox_label->set_visible_window( false );
+#if GTKMM_CHECK_VERSION(3,0,0)
+            m_label->unset_color( Gtk::STATE_FLAG_NORMAL );
+#else
             m_label->unset_fg( Gtk::STATE_NORMAL );
+#endif
         }
     }
     else{

--- a/src/skeleton/toolbar.cpp
+++ b/src/skeleton/toolbar.cpp
@@ -299,7 +299,11 @@ Gtk::ToolItem* ToolBar::get_label()
         m_ebox_label = Gtk::manage( new Gtk::EventBox );
         m_label = Gtk::manage( new Gtk::Label );
 
+#if GTKMM_CHECK_VERSION(2,6,0)
+        m_label->set_ellipsize( Pango::ELLIPSIZE_END );
+#else
         m_label->set_size_request( 0, 0 );
+#endif
         m_label->set_alignment( Gtk::ALIGN_START );
         m_label->set_selectable( true );
 

--- a/src/skeleton/toolbar.cpp
+++ b/src/skeleton/toolbar.cpp
@@ -205,6 +205,14 @@ void ToolBar::update_button()
 }
 
 
+// 閉じるボタンがキャンセルされたときに呼び出す
+void ToolBar::cancel_button_close()
+{
+    Gtk::Button* const button = dynamic_cast< Gtk::Button* >( m_button_close->get_child() );
+    button->map();
+}
+
+
 // ボタンのアンパック
 void ToolBar::unpack_buttons()
 {

--- a/src/skeleton/toolbar.cpp
+++ b/src/skeleton/toolbar.cpp
@@ -1053,3 +1053,110 @@ void ToolBar::slot_lock_clicked()
     if( ! m_enable_slot ) return;
     m_admin->set_command( "toolbar_lock_view", get_url() );
 }
+
+
+#if GTKMM_CHECK_VERSION(3,0,0)
+// 再設定用のコンテキストメニューCSS
+// 設定が必要なGTKテーマが増えるならファイルを分けるほうがいいかもしれない
+namespace TOOLBAR_CONTEXT_MENU_CSS
+{
+    // GTKテーマ Ambiance
+    constexpr const char* AMBIANCE = u8R"(
+    .toolbar .menuitem {
+        background-color: shade (@dark_bg_color, 1.08);
+        color: @dark_fg_color;
+
+        -GtkMenuItem-horizontal-padding: 0;
+        background-image: none;
+        border-radius: 0;
+        padding: 3px 5px 3px 5px;
+        text-shadow: none;
+    }
+
+    .toolbar .menuitem:hover {
+        border-radius: 0;
+        background-image: -gtk-gradient (linear, left top, left bottom,
+                                         from (shade (@selected_bg_color, 1.1)),
+                                         to (shade (@selected_bg_color, 0.9)));
+        border-image: -gtk-gradient (linear, left top, left bottom,
+                                     from (shade (@selected_bg_color, 0.7)),
+                                     to (shade (@selected_bg_color, 0.7))) 1;
+        border-image-width: 1px;
+        box-shadow: inset 1px 0 shade (@selected_bg_color, 1.02),
+                    inset -1px 0 shade (@selected_bg_color, 1.02),
+                    inset 0 1px shade (@selected_bg_color, 1.16),
+                    inset 0 -1px shade (@selected_bg_color, 0.96);
+
+        color: @selected_fg_color;
+        text-shadow: 0 -1px shade (@selected_bg_color, 0.7);
+    }
+
+    .toolbar .menuitem:insensitive,
+    .toolbar .menuitem *:insensitive {
+        color: mix (@dark_fg_color, @dark_bg_color, 0.5);
+        text-shadow: 0 -1px shade (@dark_bg_color, 0.6);
+    }
+
+    .toolbar .menuitem .accelerator {
+        color: alpha (@dark_fg_color, 0.5);
+    }
+
+    .toolbar .menuitem .accelerator:hover {
+        color: alpha (@selected_fg_color, 0.8);
+    }
+
+    .toolbar .menuitem .accelerator:insensitive {
+        color: alpha (mix (@dark_fg_color, @dark_bg_color, 0.5), 0.5);
+        text-shadow: 0 -1px shade (@dark_bg_color, 0.7);
+    }
+
+    .toolbar .menuitem.separator {
+        -GtkMenuItem-horizontal-padding: 0;
+        border-width: 1px;
+        color: @dark_bg_color;
+    }
+
+    .toolbar .menuitem.separator {
+        border-color: shade (@dark_bg_color, 0.99);
+        border-bottom-color: alpha (shade (@dark_bg_color, 1.26), 0.5);
+        border-right-color: alpha (shade (@dark_bg_color, 1.26), 0.5);
+    }
+    )";
+}
+
+//
+// ツールバーアイテムのコンテキストメニューの色を設定しなおす
+// XXX: GTKテーマごとに処理を分けているが妥当であるか不明
+//
+void ToolBar::override_context_menu_color()
+{
+    const auto settings = Gtk::Settings::get_default();
+    if( !settings ) return;
+    const Glib::ustring theme_name = settings->property_gtk_theme_name();
+#ifdef _DEBUG
+    std::cout << "GTK Theme: " << theme_name << std::endl;
+#endif
+
+    const char* css = nullptr;
+    if( theme_name == "Ambiance" ) {
+        css = TOOLBAR_CONTEXT_MENU_CSS::AMBIANCE;
+    }
+
+    if( css ) {
+        auto provider = Gtk::CssProvider::create();
+        try {
+            provider->load_from_data( css );
+        }
+        catch( Gtk::CssProviderError& err ) {
+#ifdef _DEBUG
+            std::cout << "ERROR:JDEntry css load from data failed: "
+                      << err.what() << std::endl;
+#endif
+            return;
+        }
+        Gtk::StyleContext::add_provider_for_screen(
+            Gdk::Screen::get_default(), provider,
+            GTK_STYLE_PROVIDER_PRIORITY_APPLICATION );
+    }
+}
+#endif // GTKMM_CHECK_VERSION(3,0,0)

--- a/src/skeleton/toolbar.cpp
+++ b/src/skeleton/toolbar.cpp
@@ -343,8 +343,13 @@ void ToolBar::set_color( const std::string& color )
 
         m_ebox_label->set_visible_window( true );
         m_label->modify_fg( Gtk::STATE_NORMAL, Gdk::Color( "white" ) );
+#if GTKMM_CHECK_VERSION(3,0,0)
+        m_ebox_label->override_background_color( Gdk::RGBA( color ), Gtk::STATE_FLAG_NORMAL );
+        m_ebox_label->override_background_color( Gdk::RGBA( color ), Gtk::STATE_FLAG_ACTIVE );
+#else
         m_ebox_label->modify_bg( Gtk::STATE_NORMAL, Gdk::Color( color ) );
         m_ebox_label->modify_bg( Gtk::STATE_ACTIVE, Gdk::Color( color ) );
+#endif
     }
 }
 

--- a/src/skeleton/toolbar.cpp
+++ b/src/skeleton/toolbar.cpp
@@ -28,7 +28,9 @@
 #include "prefdiagfactory.h"
 
 #include <gtk/gtk.h>  // gtk_separator_tool_item_set_draw
+#if !GTKMM_CHECK_VERSION(3,0,0)
 #include <gtk/gtkbutton.h>
+#endif
 #include <list>
 
 using namespace SKELETON;
@@ -729,6 +731,7 @@ void ToolBar::focus_button_write()
 // 書き込みボタンの廻りに枠を描く
 void ToolBar::drawframe_button_write( const bool draw )
 {
+#if !GTKMM_CHECK_VERSION(3,0,0)
     if( CONFIG::get_flat_button() ){
 
         // relief が Gtk:: RELIEF_NONE のときにボタンに枠を描画
@@ -742,6 +745,7 @@ void ToolBar::drawframe_button_write( const bool draw )
             else gtk_button_leave( gtkbutton );
         }
     }
+#endif // !GTKMM_CHECK_VERSION(3,0,0)
 }
 
 

--- a/src/skeleton/toolbar.h
+++ b/src/skeleton/toolbar.h
@@ -29,7 +29,7 @@ namespace SKELETON
 
         bool m_enable_slot;
 
-#if !GTKMM_CHECK_VERSION(2,13,0)
+#if !GTKMM_CHECK_VERSION(2,12,0)
         Gtk::Tooltips m_tooltip;
 #endif
 

--- a/src/skeleton/toolbar.h
+++ b/src/skeleton/toolbar.h
@@ -108,6 +108,10 @@ namespace SKELETON
         // ボタン表示更新
         void update_button();
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+        static void override_context_menu_color();
+#endif
+
       protected:
 
         SKELETON::Admin* get_admin(){ return m_admin; }

--- a/src/skeleton/toolbar.h
+++ b/src/skeleton/toolbar.h
@@ -112,6 +112,9 @@ namespace SKELETON
         static void override_context_menu_color();
 #endif
 
+        // 閉じるボタンがキャンセルされたときに呼び出す
+        void cancel_button_close();
+
       protected:
 
         SKELETON::Admin* get_admin(){ return m_admin; }

--- a/src/skeleton/toolbarnote.cpp
+++ b/src/skeleton/toolbarnote.cpp
@@ -35,6 +35,7 @@ ToolBarNotebook::ToolBarNotebook( DragableNoteBook* parent )
 //
 // 自前でビュー領域の枠を描画する
 //
+#if !GTKMM_CHECK_VERSION(3,0,0)
 bool ToolBarNotebook::on_expose_event( GdkEventExpose* event )
 {
     // 枠描画
@@ -48,3 +49,4 @@ bool ToolBarNotebook::on_expose_event( GdkEventExpose* event )
 
     return ret;
 }
+#endif // !GTKMM_CHECK_VERSION(3,0,0)

--- a/src/skeleton/toolbarnote.cpp
+++ b/src/skeleton/toolbarnote.cpp
@@ -19,9 +19,14 @@ ToolBarNotebook::ToolBarNotebook( DragableNoteBook* parent )
     set_show_tabs( false );
     set_border_width( 0 );
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+    set_margin_top( 1 );
+    set_margin_bottom( 1 );
+#else
     Glib::RefPtr< Gtk::RcStyle > rcst = get_modifier_style();
     rcst->set_ythickness( 1 );
     modify_style( rcst );
+#endif // GTKMM_CHECK_VERSION(3,0,0)
 }
 
 

--- a/src/skeleton/toolbarnote.h
+++ b/src/skeleton/toolbarnote.h
@@ -20,9 +20,11 @@ namespace SKELETON
 
         ToolBarNotebook( DragableNoteBook* parent );
 
+#if !GTKMM_CHECK_VERSION(3,0,0)
       protected:
 
         virtual bool on_expose_event( GdkEventExpose* event );
+#endif
     };
 }
 

--- a/src/skeleton/tooltip.cpp
+++ b/src/skeleton/tooltip.cpp
@@ -76,8 +76,12 @@ void Tooltip::show_tooltip()
 #endif
 
     int x_mouse, y_mouse;
+#if GTKMM_CHECK_VERSION(3,0,0)
+    Gdk::Display::get_default()->get_device_manager()->get_client_pointer()->get_position( x_mouse, y_mouse );
+#else
     Gdk::ModifierType mod;
     Gdk::Display::get_default()->get_pointer( x_mouse, y_mouse,  mod );
+#endif
 
     // 一度画面外にshow()して幅を確定してから、もし m_min_width よりも
     // 幅が大きければマウスの位置に移動する

--- a/src/skeleton/tooltip.cpp
+++ b/src/skeleton/tooltip.cpp
@@ -28,7 +28,11 @@ void Tooltip::modify_font_label( const std::string& fontname )
 {
     Pango::FontDescription pfd( fontname );
     pfd.set_weight( Pango::WEIGHT_NORMAL );
+#if GTKMM_CHECK_VERSION(3,0,0)
+    m_label.override_font( pfd );
+#else
     m_label.modify_font( pfd );
+#endif
 }
 
 

--- a/src/skeleton/treeviewbase.cpp
+++ b/src/skeleton/treeviewbase.cpp
@@ -179,7 +179,7 @@ void JDTreeViewBase::goto_bottom()
 {
     if( ! get_row_size() ) return;
 
-    Gtk::TreePath path = get_model()->get_path( *( get_model()->children().rbegin() ) );
+    Gtk::TreePath path = get_model()->get_path( *( std::prev( get_model()->children().end() ) ) );
 
     // ディレクトリを開いている時、一番下の行に移動
     Gtk::TreePath path_prev = path;

--- a/src/skeleton/treeviewbase.cpp
+++ b/src/skeleton/treeviewbase.cpp
@@ -40,11 +40,11 @@ const int JDTreeViewBase::get_row_size()
 Gtk::TreeModel::Path JDTreeViewBase::get_current_path()
 {
     Gtk::TreeModel::Path path;
-    
-    std::list< Gtk::TreeModel::Path > paths = get_selection()->get_selected_rows();
+
+    std::vector< Gtk::TreeModel::Path > paths = get_selection()->get_selected_rows();
     if( paths.size() ){
-    
-        std::list< Gtk::TreeModel::Path >::iterator it = paths.begin();
+
+        std::vector< Gtk::TreeModel::Path >::iterator it = paths.begin();
         path = ( *it );
     }
 
@@ -115,8 +115,8 @@ std::list< Gtk::TreeModel::iterator > JDTreeViewBase::get_selected_iterators()
     
     if( get_model() ){
 
-        std::list< Gtk::TreeModel::Path > paths = get_selection()->get_selected_rows();
-        std::list< Gtk::TreeModel::Path >::iterator it = paths.begin();
+        std::vector< Gtk::TreeModel::Path > paths = get_selection()->get_selected_rows();
+        std::vector< Gtk::TreeModel::Path >::iterator it = paths.begin();
         for( ; it != paths.end(); ++it ) list_it.push_back( get_model()->get_iter( ( *it ) ) );
     }
 
@@ -129,7 +129,7 @@ std::list< Gtk::TreeModel::iterator > JDTreeViewBase::get_selected_iterators()
 //
 void JDTreeViewBase::delete_selected_rows( const bool force )
 {
-    std::list< Gtk::TreeModel::Path > list_path = get_selection()->get_selected_rows();
+    std::vector< Gtk::TreeModel::Path > list_path = get_selection()->get_selected_rows();
 
     if( ! list_path.size() ) return;
 
@@ -146,7 +146,7 @@ void JDTreeViewBase::delete_selected_rows( const bool force )
     const bool gotobottom = ( ! get_row( next ) );
     if( ! gotobottom ) set_cursor( next );
 
-    std::list< Gtk::TreePath >::reverse_iterator it = list_path.rbegin();
+    std::vector< Gtk::TreePath >::reverse_iterator it = list_path.rbegin();
     for( ; it != list_path.rend(); ++it ){
         Gtk::TreeRow row = get_row( *it );
 

--- a/src/skeleton/treeviewbase.cpp
+++ b/src/skeleton/treeviewbase.cpp
@@ -236,7 +236,7 @@ void JDTreeViewBase::page_up()
     bool set_top = false;
 
     // スクロール
-    Gtk::Adjustment *adj = get_vadjustment();
+    auto adj = get_vadjustment();
     double val = adj->get_value();
     if( val > adj->get_page_size()/2 ) set_top = true;
     val = MAX( 0, val - adj->get_page_size() );
@@ -258,7 +258,7 @@ void JDTreeViewBase::page_down()
     bool set_bottom = false;
 
     // スクロール
-    Gtk::Adjustment *adj = get_vadjustment();
+    auto adj = get_vadjustment();
     double val = adj->get_value();
     if( val < adj->get_upper() - adj->get_page_size() - adj->get_page_size()/2 ) set_bottom = true;
     val = MIN( adj->get_upper() - adj->get_page_size(), val + adj->get_page_size() );

--- a/src/skeleton/view.cpp
+++ b/src/skeleton/view.cpp
@@ -1,6 +1,7 @@
 // ライセンス: GPL2
 
 //#define _DEBUG
+#include "gtkmmversion.h"
 #include "jddebug.h"
 
 #include "admin.h"
@@ -15,6 +16,10 @@
 #include "global.h"
 #include "session.h"
 #include "command.h"
+
+#if GTKMM_CHECK_VERSION(3,0,0)
+#include <gdk/gdkkeysyms-compat.h>
+#endif
 
 using namespace SKELETON;
 

--- a/src/skeleton/viewnote.cpp
+++ b/src/skeleton/viewnote.cpp
@@ -29,6 +29,7 @@ ViewNotebook::ViewNotebook( DragableNoteBook* parent )
 //
 // 自前で枠を描画する
 //
+#if !GTKMM_CHECK_VERSION(3,0,0)
 bool ViewNotebook::on_expose_event( GdkEventExpose* event )
 {
     if( ! get_n_pages() ) return Notebook::on_expose_event( event );
@@ -44,6 +45,7 @@ bool ViewNotebook::on_expose_event( GdkEventExpose* event )
 
     return ret;
 }
+#endif // !GTKMM_CHECK_VERSION(3,0,0)
 
 
 //

--- a/src/skeleton/viewnote.h
+++ b/src/skeleton/viewnote.h
@@ -22,9 +22,11 @@ namespace SKELETON
 
         void redraw_scrollbar();
 
+#if !GTKMM_CHECK_VERSION(3,0,0)
       protected:
 
         virtual bool on_expose_event( GdkEventExpose* event );
+#endif
     };
 }
 

--- a/src/skeleton/window.cpp
+++ b/src/skeleton/window.cpp
@@ -455,8 +455,13 @@ void JDWindow::set_status_color( const std::string& color )
     }
     else{
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+        m_label_stat.override_color( Gdk::RGBA( "white" ), Gtk::STATE_FLAG_NORMAL );
+        m_mginfo.override_color( Gdk::RGBA( "white" ), Gtk::STATE_FLAG_NORMAL );
+#else
         m_label_stat.modify_fg( Gtk::STATE_NORMAL, Gdk::Color( "white" ) );
         m_mginfo.modify_fg( Gtk::STATE_NORMAL, Gdk::Color( "white" ) );
+#endif
 
         m_label_stat_ebox.set_visible_window( true );
 #if GTKMM_CHECK_VERSION(3,0,0)

--- a/src/skeleton/window.cpp
+++ b/src/skeleton/window.cpp
@@ -383,7 +383,11 @@ void JDWindow::set_status( const std::string& stat )
 
 #if GTKMM_CHECK_VERSION(2,5,0)
     m_label_stat.set_text( stat );
+#if GTKMM_CHECK_VERSION(2,12,0)
+    m_label_stat_ebox.set_tooltip_text( stat );
+#else
     m_tooltip.set_tip( m_label_stat_ebox, stat );
+#endif
 #else
     m_statbar.push( stat );
 #endif

--- a/src/skeleton/window.cpp
+++ b/src/skeleton/window.cpp
@@ -4,6 +4,9 @@
 #include "jddebug.h"
 
 #include "window.h"
+#if GTKMM_CHECK_VERSION(3,0,0)
+#include "toolbar.h"
+#endif
 
 #include "config/globalconf.h"
 
@@ -94,6 +97,12 @@ JDWindow::JDWindow( const bool fold_when_focusout, const bool need_mginfo )
     m_gtkwindow = GTK_WINDOW( gobj() );
     gpointer parent_class = g_type_class_peek_parent( G_OBJECT_GET_CLASS( gobj() ) );
     m_grand_parent_class = g_type_class_peek_parent( parent_class );
+
+#if GTKMM_CHECK_VERSION(3,0,0)
+    // ツールバーアイテムのコンテキストメニューの色がGTKテーマと違う場合がある
+    // XXX: コンテキストメニューの色をアプリケーションで設定しなおす
+    SKELETON::ToolBar::override_context_menu_color();
+#endif
 }
 
 

--- a/src/skeleton/window.cpp
+++ b/src/skeleton/window.cpp
@@ -446,8 +446,13 @@ void JDWindow::set_status_color( const std::string& color )
     if( color.empty() ){
 
         if( m_label_stat_ebox.get_visible_window() ){
+#if GTKMM_CHECK_VERSION(3,0,0)
+            m_label_stat.unset_color( Gtk::STATE_FLAG_NORMAL );
+            m_mginfo.unset_color( Gtk::STATE_FLAG_NORMAL );
+#else
             m_label_stat.unset_fg( Gtk::STATE_NORMAL );
             m_mginfo.unset_fg( Gtk::STATE_NORMAL );
+#endif
 
             m_label_stat_ebox.set_visible_window( false );
             m_mginfo_ebox.set_visible_window( false );

--- a/src/skeleton/window.cpp
+++ b/src/skeleton/window.cpp
@@ -459,12 +459,22 @@ void JDWindow::set_status_color( const std::string& color )
         m_mginfo.modify_fg( Gtk::STATE_NORMAL, Gdk::Color( "white" ) );
 
         m_label_stat_ebox.set_visible_window( true );
+#if GTKMM_CHECK_VERSION(3,0,0)
+        m_label_stat_ebox.override_background_color( Gdk::RGBA( color ), Gtk::STATE_FLAG_NORMAL );
+        m_label_stat_ebox.override_background_color( Gdk::RGBA( color ), Gtk::STATE_FLAG_ACTIVE );
+#else
         m_label_stat_ebox.modify_bg( Gtk::STATE_NORMAL, Gdk::Color( color ) );
         m_label_stat_ebox.modify_bg( Gtk::STATE_ACTIVE, Gdk::Color( color ) );
+#endif
 
         m_mginfo_ebox.set_visible_window( true );
+#if GTKMM_CHECK_VERSION(3,0,0)
+        m_mginfo_ebox.override_background_color( Gdk::RGBA( color ), Gtk::STATE_FLAG_NORMAL );
+        m_mginfo_ebox.override_background_color( Gdk::RGBA( color ), Gtk::STATE_FLAG_ACTIVE );
+#else
         m_mginfo_ebox.modify_bg( Gtk::STATE_NORMAL, Gdk::Color( color ) );
         m_mginfo_ebox.modify_bg( Gtk::STATE_ACTIVE, Gdk::Color( color ) );
+#endif
     }
 #endif
 }

--- a/src/skeleton/window.h
+++ b/src/skeleton/window.h
@@ -45,7 +45,9 @@ namespace SKELETON
         Gtk::Label m_label_stat;
         Gtk::EventBox m_label_stat_ebox;
         Gtk::EventBox m_mginfo_ebox;
+#if !GTKMM_CHECK_VERSION(2,12,0)
         Gtk::Tooltips m_tooltip;
+#endif
 #else
         Gtk::Statusbar m_statbar;
 #endif

--- a/src/winmain.cpp
+++ b/src/winmain.cpp
@@ -48,7 +48,7 @@ JDWinMain::JDWinMain( const bool init, const bool skip_setupdiag,
 #ifndef _WIN32
     // アイコンをセット
     // WindowsはwindresのデフォルトICONが初期適用されるので不要
-    std::list< Glib::RefPtr< Gdk::Pixbuf > > list_icons;
+    std::vector< Glib::RefPtr< Gdk::Pixbuf > > list_icons;
     list_icons.push_back( ICON::get_icon( ICON::JD16 ) );
     list_icons.push_back( ICON::get_icon( ICON::JD32 ) );
     list_icons.push_back( ICON::get_icon( ICON::JD48 ) );


### PR DESCRIPTION
*このPRはマージしません*
gtkmm-2.4のかわりにgtkmm-3.0を使ってJDをビルドするオプションを追加します。

[INSTALL](https://github.com/ma8ma/JD/blob/gtk3-idea-r2/INSTALL)や[README.md](https://github.com/ma8ma/JD/blob/gtk3-idea-r2/README.md)にも情報が載っているのでそちらも参照してください。

## 注意
* **開発版(alpha)の段階なのでビルドに失敗したり、動作中にクラッシュ、フリーズやメモリリークする可能性があります。**
* gtk2/3でUIのルック・アンド・フィールが異なる部分があります。
* 応急処置/暫定の変更が含まれています。
* ビルドのオプションに関係なく**プロファイルは共通**です。大事なデータはバックアップをしてから試してください。

## 要件
JDの導入方法に加えて以下が必要です
* C++11に対応したコンパイラ
* `gtkmm-3.0` (バージョン3.18以上を推奨、Ubuntuでは`libgtkmm-3.0-dev`をインストール)
* `AX_CXX_COMPILE_STDCXX_11`を使うためのautoconfのパッケージ(Ubuntuでは`autoconf-archive`をインストール)

## configureのフラグ
* `--with-gtkmm3` gtkmm-2.4のかわりにgtkmm-3.0を使う（デフォルトは=no）
* `--with-stdthread` pthreadのかわりにstd::threadを使う（デフォルトは=no）

２つのフラグは独立しているのでgtkmm3とpthreadまたはgthreadの組み合わせでビルドできます。（逆にgtkmm2とstdthreadの組み合わせも可能）

## ビルド
リモートを追加してgtk3-idea-r2ブランチをフェッチしチェックアウトするかリポジトリをクローンします。
./configureのフラグを追加してビルドしてください
```bash
# 既存のリポジトリにリモートを追加する場合
$ cd /path/to/JD
$ git remote add ma8ma https://github.com/ma8ma/JD.git
$ git fetch ma8ma gtk3-idea-r2
$ git checkout -b gtk3-idea-r2 --track remotes/ma8ma/gtk3-idea-r2
$ autoreconf -i
$ ./configure (...) --with-stdthread --with-gtkmm3
$ make
```

## 既知の問題
* gtk3のビルドで板ビューのマウスホイールによるスクロールが動作しない
  → 環境変数`GDK_CORE_DEVICE_EVENTS=1`を設定します
* gtk3のビルドではタブの上でマウスホイールをしてもスレッドや板が切り替わらない  
  → gtk3で機能が削除されています
* LXDEでgtk2のビルドを動作させると特定の状況（ポップアップが被っていた場所やタブのドラッグ後）でスレビューが描画が汚くなることがある
  → LXDE + gtk2 + cairoの組み合わせは相性が悪い？
* GTKテーマによってはUIの配色に問題がある

## 修正の説明

### jd-2.90.0-alpha180915 (ma8ma/JD#1) からの変更点
スタイルや不具合を修正したPRであり、機能の追加/削除など大きな変更はありません。

* コーディングスタイルを変更し1行の最大文字数は設定しなくなった。
  コードは読みやすい位置で改行する。
* README.mdやINSTALLに情報を追加しC++11の機能を使うことを明確にした。
* 新たに見つけた不具合を修正した。
* 複雑だったコードを書き直した。

### 修正のルール

#### コーディングスタイル
* clang-formatで修正した部分を整形しています。（一部は手直し）
* JDのコードをベースに設定を作っていますが、設定できないスタイルや意図的に変更したポイントがあります。(https://github.com/ma8ma/JD/commit/08922a02e110c669d55e28d34a1201a080a09f34 を参照)

#### コミット
* コミットメッセージのサブジェクトの先頭に修正タイプをつけています (E=compile error, C=crash, B=behavior)
* 変更の余地が大きいコミットとして`QUICKFIX`は応急処置、`PROVISIONAL`は暫定を表します
* コミットは大別してgtk2から有効な変更`[gtk2]`とgtk3にのみ影響を与える変更`[gtk3]`があります

#### 実装の方針
* gtkの機能を使います(同じような機能は作らない)
* 実装の詳細を使う(gtkのソースコードを引用する)ロジックは避けます
* gtk3で削除された機能は自前で再実装しません
