### PR TITLE
Fix compile error for debug log

### DIFF
--- a/src/skeleton/toolbar.cpp
+++ b/src/skeleton/toolbar.cpp
@@ -1121,7 +1121,7 @@ void ToolBar::setup_manual_styling( Gtk::ToolButton& toolbutton )
     }
     catch( Gtk::CssProviderError& err ) {
 #ifdef _DEBUG
-        std::cout << "ToolBar::set_custom_flat_relief load css failed." < < < < err.what() << std::endl;
+        std::cout << "ToolBar::set_custom_flat_relief load css failed." << err.what() << std::endl;
 #endif
     }
 


### PR DESCRIPTION
_DEBUGを定義するとコンパイルエラーが起こる不具合を修正します。
https://github.com/ma8ma/JD/pull/9#issuecomment-443494237