### PR TITLE
Draw popup window in wayland

### DIFF
--- a/src/skeleton/popupwinbase.h
+++ b/src/skeleton/popupwinbase.h
@@ -11,6 +11,10 @@
 
 #include <gtkmm.h>
 
+#if GTKMM_CHECK_VERSION(3,0,0)
+#include "command.h"
+#endif
+
 namespace SKELETON
 {
     enum
@@ -39,6 +43,12 @@ namespace SKELETON
         // draw_frame == true なら枠を描画する
         PopupWinBase( bool draw_frame ) : Gtk::Window( Gtk::WINDOW_POPUP ), m_draw_frame( draw_frame ){
             if( m_draw_frame ) set_border_width( 1 );
+
+#if GTKMM_CHECK_VERSION(3,0,0)
+            if ( auto main_window = CORE::get_mainwindow() ) {
+                set_transient_for( *main_window );
+            }
+#endif
         }
         ~PopupWinBase() noexcept {}
 


### PR DESCRIPTION
Gtk3版をWaylandで実行すると
ポップアップウィンドウ(`SKELETON::PopupWinBase`)が表示されないようです。

[\[gtk+\] wayland: prefer subsurface when possible](https://mail.gnome.org/archives/commits-list/2016-January/msg02035.html)によると
`GTK_WINDOW_POPUP`のような一時ウィンドウをX11と同様に描画するには
`gtk_window_transient_for`で親ウィンドウを設定する必要があるそうなので
そうするように`PopupWinBase`を変更しました。
